### PR TITLE
Fix loading OTB Editor

### DIFF
--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -112,9 +112,9 @@ namespace Assets_Editor
                     Appearances.Missile.Add(appearance);
                 }
             }
-            catch
+            catch (Exception e)
             {
-                throw new Exception("Couldn't load dat file");
+                throw new Exception("Couldn't load dat file", e);
             }
         }
 

--- a/Assets Editor/OTBEditor.xaml.cs
+++ b/Assets Editor/OTBEditor.xaml.cs
@@ -123,7 +123,10 @@ namespace Assets_Editor
                         if (_legacy)
                         {
                             ShowList item = (ShowList)ItemListView.Items[i];
-                            item.Image = Utils.BitmapToBitmapImage(LegacyAppearance.GetObjectImage(appearanceByClientId[item.Cid], MainWindow.MainSprStorage));
+                            if (appearanceByClientId.ContainsKey(item.Cid))
+                            {
+                                item.Image = Utils.BitmapToBitmapImage(LegacyAppearance.GetObjectImage(appearanceByClientId[item.Cid], MainWindow.MainSprStorage));
+                            }
                         }
                         else
                         {
@@ -195,6 +198,11 @@ namespace Assets_Editor
             NewItemListView.Items.Clear();
             foreach (ServerItem item in OTBItems)
             {
+                if (!appearanceByClientId.ContainsKey(item.ClientId))
+                {
+                    continue;
+                }
+
                 ServerItem citem = new ServerItem(appearanceByClientId[item.ClientId]);
                 if (!Utils.ByteArrayCompare(item.SpriteHash,citem.SpriteHash))
                 {


### PR DESCRIPTION
I have items.otb file, which didn't exactly match what client .dat file has.
This resulted in failing to load the OTB editor.

This fix makes sure we skip loading items when they don't match.