### PR TITLE
Improve Sprite Editor

### DIFF
--- a/Assets Editor/AssetsEditor.csproj
+++ b/Assets Editor/AssetsEditor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>Assets_Editor</RootNamespace>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -112,11 +112,6 @@
                 <StackPanel Grid.Row="0" Orientation="Horizontal">
                     <Menu IsMainMenu="True" materialDesign:MenuAssist.TopLevelMenuItemHeight="30">
                         <MenuItem Header="_File">
-                            <MenuItem Header="Exit" InputGestureText="Ctrl+E" Click="Exit_Click">
-                                <MenuItem.Icon>
-                                    <materialDesign:PackIcon Kind="ExitToApp" />
-                                </MenuItem.Icon>
-                            </MenuItem>
                             <MenuItem Header="Compile" Click="Compile_Click">
                                 <MenuItem.Icon>
                                     <materialDesign:PackIcon Kind="ContentSaveCogOutline" />
@@ -553,7 +548,30 @@
                         <RowDefinition Height="30"/>
                         <RowDefinition Height="40"/>
                     </Grid.RowDefinitions>
-                    <ListView Grid.Row="0" Grid.Column="0" Margin="0,5,0,0" x:Name="SprListView" HorizontalAlignment="Center" VerticalAlignment="Stretch" VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.IsVirtualizing="True" SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.ScrollChanged="SprListView_ScrollChanged" MouseMove="SprListView_DragSpr" SelectedIndex="0" Width="207">
+                    <ListView Grid.Row="0" Grid.Column="0" Margin="0,5,0,0" x:Name="SprListView"
+                              HorizontalAlignment="Center" VerticalAlignment="Stretch"
+                              VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.IsVirtualizing="True"
+                              SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                              ScrollViewer.ScrollChanged="SprListView_ScrollChanged" MouseMove="SprListView_DragSpr"
+                              SelectedIndex="0" Width="207">
+                        <ListView.Resources>
+                            <ContextMenu x:Key="RowContextMenu">
+                                <MenuItem Header="Edit Sprite" Click="EditSprite_Click"/>
+                            </ContextMenu>
+                        </ListView.Resources>
+                        <ListView.ItemContainerStyle>
+                            <Style TargetType="ListViewItem">
+                                <Setter Property="ContextMenu" Value="{StaticResource RowContextMenu}"/>
+                                <Style.Triggers>
+                                    <Trigger Property="IsFocused" Value="True">
+                                        <Setter Property="Background" Value="Transparent"></Setter>
+                                    </Trigger>
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter Property="Background" Value="Transparent"></Setter>
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </ListView.ItemContainerStyle>
                         <ListView.View>
                             <GridView AllowsColumnReorder="False">
                                 <GridView.ColumnHeaderContainerStyle>

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -135,7 +135,14 @@ namespace Assets_Editor
                 for (int i = 0; i < SprListView.Items.Count; i++)
                 {
                     if (i >= offset && i < Math.Min(offset + 20, SprListView.Items.Count) && MainWindow.SprLists.ContainsKey(i))
-                        MainWindow.AllSprList[i].Image = Utils.BitmapToBitmapImage(MainWindow.getSpriteStream(i));
+                        try
+                        {
+                            MainWindow.AllSprList[i].Image = Utils.BitmapToBitmapImage(MainWindow.getSpriteStream(i));
+                        }
+                        catch (Exception ex)
+                        {
+                            MainWindow.AllSprList[i].Image = null;
+                        }
                     else
                         MainWindow.AllSprList[i].Image = null;
                 }
@@ -2010,6 +2017,17 @@ namespace Assets_Editor
         {
             AboutWindow aboutWindow = new AboutWindow();
             aboutWindow.Show();
+        }
+
+        private void EditSprite_Click(object sender, RoutedEventArgs e)
+        {
+            if (sender is not MenuItem menuItem) return;
+            if (menuItem.DataContext is not ShowList showList) return;
+            
+            SprEditor sprEditor = new SprEditor(this);
+            SprEditor.CustomSheetsList.Clear();
+            sprEditor.Show();
+            sprEditor.OpenForSpriteId((int)showList.Id);
         }
     }
 }

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
@@ -1662,8 +1663,7 @@ namespace Assets_Editor
 
             // Handle any remaining sprites in the last sheet
             finalizeSheet();
-            SprListView.ItemsSource = null;
-            SprListView.ItemsSource = MainWindow.AllSprList;
+            CollectionViewSource.GetDefaultView(SprListView.ItemsSource).Refresh();
 
             if (currentSheet != null) currentSheet.Dispose();
             if (graphics != null) graphics.Dispose();

--- a/Assets Editor/ImportManager.xaml.cs
+++ b/Assets Editor/ImportManager.xaml.cs
@@ -257,8 +257,8 @@ namespace Assets_Editor
                     MainWindow.AllSprList.Add(new ShowList() { Id = (uint)sprId });
 
                 }
-                _editor.SprListView.ItemsSource = null;
-                _editor.SprListView.ItemsSource = MainWindow.AllSprList;
+                
+                CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
             }
         }
 
@@ -277,8 +277,7 @@ namespace Assets_Editor
                     ObjectAppearance.FrameGroup[(int)i].SpriteInfo.SpriteId[(int)s] = (uint)sprId;
                 }
             }
-            _editor.SprListView.ItemsSource = null;
-            _editor.SprListView.ItemsSource = MainWindow.AllSprList;
+            CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
         }
 
         private void updateObjectAppearanceSprite(Appearance ObjectAppearance, ConcurrentDictionary<int, MemoryStream> list)
@@ -296,8 +295,8 @@ namespace Assets_Editor
                     ObjectAppearance.FrameGroup[(int)i].SpriteInfo.SpriteId[(int)s] = (uint)sprId;
                 }
             }
-            _editor.SprListView.ItemsSource = null;
-            _editor.SprListView.ItemsSource = MainWindow.AllSprList;
+            
+            CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
         }
 
         private void ObjectImport_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
@@ -372,8 +371,7 @@ namespace Assets_Editor
                         ObjectAppearance.FrameGroup[(int)i].SpriteInfo.SpriteId[(int)s] = (uint)sprId;
                     }
                 }
-                _editor.SprListView.ItemsSource = null;
-                _editor.SprListView.ItemsSource = MainWindow.AllSprList;
+                CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
                 SpriteInfo NewSpriteInfo = spriteInfo.Clone();
                 NewSpriteInfo.SpriteId.Clear();
                 int counter = 0;

--- a/Assets Editor/LegacyDatEditor.xaml.cs
+++ b/Assets Editor/LegacyDatEditor.xaml.cs
@@ -1171,8 +1171,7 @@ namespace Assets_Editor
                                     int sprId = MainWindow.SprLists.Count;
                                     MainWindow.SprLists[sprId] = imgMemory;
                                     MainWindow.AllSprList.Add(new ShowList() { Id = (uint)sprId });
-                                    SprListView.ItemsSource = null;
-                                    SprListView.ItemsSource = MainWindow.AllSprList;
+                                    CollectionViewSource.GetDefaultView(SprListView.ItemsSource).Refresh();
 
                                     imported++;
                                 }
@@ -1201,8 +1200,7 @@ namespace Assets_Editor
                     MainWindow.SprLists[(int)data.Id].Position = 0;
                     using System.Drawing.Bitmap emptyBitmap = new System.Drawing.Bitmap(32, 32, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
                     emptyBitmap.Save(MainWindow.SprLists[(int)data.Id], ImageFormat.Png);
-                    SprListView.ItemsSource = null;
-                    SprListView.ItemsSource = MainWindow.AllSprList;
+                    CollectionViewSource.GetDefaultView(SprListView.ItemsSource).Refresh();
                     StatusBar.MessageQueue.Enqueue($"Sprite successfully removed.", null, null, null, false, true, TimeSpan.FromSeconds(2));
                 }
                 else
@@ -1230,8 +1228,7 @@ namespace Assets_Editor
                         {
                             removedStream.Dispose();
                             MainWindow.AllSprList.RemoveAt((int)data.Id);
-                            SprListView.ItemsSource = null;
-                            SprListView.ItemsSource = MainWindow.AllSprList;
+                            CollectionViewSource.GetDefaultView(SprListView.ItemsSource).Refresh();
                             StatusBar.MessageQueue.Enqueue($"Sprite successfully removed.", null, null, null, false, true, TimeSpan.FromSeconds(2));
                         }
                         else
@@ -1278,8 +1275,7 @@ namespace Assets_Editor
 
                         int sprId = SprListView.SelectedIndex;
                         MainWindow.SprLists[sprId] = imgMemory;
-                        SprListView.ItemsSource = null;
-                        SprListView.ItemsSource = MainWindow.AllSprList;
+                        CollectionViewSource.GetDefaultView(SprListView.ItemsSource).Refresh();
                     }
                 }
                 StatusBar.MessageQueue.Enqueue($"Sprite successfully replaced.", null, null, null, false, true, TimeSpan.FromSeconds(2));

--- a/Assets Editor/SprEditor.xaml
+++ b/Assets Editor/SprEditor.xaml
@@ -7,6 +7,10 @@
         mc:Ignorable="d"
         Title="SprEditor" Height="640" Width="700"
         Style="{StaticResource MaterialDesignWindow}">
+    <Window.CommandBindings>
+        <CommandBinding Command="Paste" Executed="OnPaste"/>
+        <CommandBinding Command="Delete" Executed="OnDelete"/>
+    </Window.CommandBindings>
     <Window.Resources>
         <local:ArithmeticConverter x:Key="ArithmeticConverter" />
         <local:NullableColorToBrushConverter x:Key="NullableColorToBrushConverter" />
@@ -42,19 +46,6 @@
             <StackPanel Grid.Row="0" Grid.Column="0">
                 <GroupBox Header="Current Sheet Viewer" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,0,10,0">
                     <WrapPanel x:Name="SheetWrap" ScrollViewer.VerticalScrollBarVisibility="Disabled" Background="#FFEAEAEA" Width="400" Height="400"/>
-                    <xctk:MagnifierManager.Magnifier>
-                        <xctk:Magnifier
-                               Background="White"
-                               Radius="80"
-                               ZoomFactor="0.3"
-                               FrameType="Circle"
-                               BorderBrush="#FFC72035"
-                               BorderThickness="2"
-                               Width="160"
-                               Height="160"
-                               IsUsingZoomOnMouseWheel="True"
-                               ZoomFactorOnMouseWheel="0.1"/>
-                    </xctk:MagnifierManager.Magnifier>
                 </GroupBox>
                 <Border BorderThickness="1" BorderBrush="#FF673AB7" Height="30" Margin="10,10,10,0" >
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -203,6 +203,7 @@ namespace Assets_Editor
             {
                 var files = Clipboard.GetFileDropList();
                 MakeFilesAsSprites(files.Cast<string>().ToArray(), focusedIndex, null);
+                EmptyTiles = false;
             }
         }
         
@@ -238,6 +239,7 @@ namespace Assets_Editor
                     var targetImage = Utils.GetLogicalChildCollection<Image>(targetBorder)[0];
                     (targetImage.Source, sourceImage.Source) = (sourceImage.Source, targetImage.Source);
                 }
+                EmptyTiles = false;
                 ClearBorders();
             }
         }

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -467,6 +467,7 @@ namespace Assets_Editor
                     }
                 }
                 SprStatusBar.MessageQueue.Enqueue($"New sheet saved.", null, null, null, false, true, TimeSpan.FromSeconds(3));
+                _editor.SprListView.ItemsSource = null;
                 _editor.SprListView.ItemsSource = MainWindow.AllSprList;
             }
             else

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -17,6 +17,7 @@ using static Assets_Editor.MainWindow;
 using System.Runtime.InteropServices;
 using Efundies;
 using System.Linq;
+using System.Windows.Controls;
 
 namespace Assets_Editor
 {
@@ -37,6 +38,8 @@ namespace Assets_Editor
         private int SprSheetHeight = 384;
         private int SprType = 0;
         private bool EmptyTiles = true;
+        private int focusedIndex = 0;
+        private BitmapSource emptyBitmapSource;
         public static ObservableCollection<ShowList> CustomSheetsList = new ObservableCollection<ShowList>();
         private Catalog CurrentSheet = null;
         private void CreateNewSheetImg(int sprType, bool modify)
@@ -67,18 +70,15 @@ namespace Assets_Editor
                 SpriteHeight = 64;
             }
 
-            List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
-            foreach (Image child in images)
-            {
-                SheetWrap.Children.Remove(child);
-            }
+            SheetWrap.Children.Clear();
 
             int stride = SpriteWidth * (96 / 8);
-            BitmapSource image = BitmapSource.Create(SpriteWidth, SpriteHeight, 96, 96, PixelFormats.Indexed8, new BitmapPalette(new List<Color> { Colors.White }), new byte[SpriteHeight * stride], stride);
+            emptyBitmapSource = BitmapSource.Create(SpriteWidth, SpriteHeight, 96, 96, PixelFormats.Indexed8,
+                new BitmapPalette(new List<Color> { Color.FromArgb(255, 255, 0, 255) }), new byte[SpriteHeight * stride], stride);
             int count = (SprSheetWidth / SpriteWidth * SprSheetHeight / SpriteHeight);
             for (int i = 0; i < count; i++)
             {
-                Image img = new Image
+                Border border = new Border
                 {
                     Width = SpriteWidth,
                     Height = SpriteHeight,
@@ -86,68 +86,210 @@ namespace Assets_Editor
                     VerticalAlignment = VerticalAlignment.Center,
                     AllowDrop = true
                 };
-                img.DragOver += Img_DragOverSheet;
-                img.Drop += Img_Drop;
-                img.Source = image;
+                border.Margin = new Thickness(1, 1, 0, 0);
+                border.MouseEnter += Border_MouseEnter;
+                border.MouseLeave += Border_MouseLeave;
+                border.MouseDown += Border_MouseDown;
+                border.DragEnter += Border_DragEnter;
+                border.DragLeave += Border_DragLeave;
+                border.Drop += Border_Drop;
+                border.Tag = i;
+                Image img = new Image
+                {
+                    Width = SpriteWidth,
+                    Height = SpriteHeight,
+                    HorizontalAlignment = HorizontalAlignment.Center,
+                    VerticalAlignment = VerticalAlignment.Center,
+                };
+                
+                img.Source = emptyBitmapSource;
                 img.Tag = i;
-                img.Margin = new Thickness(1, 1, 0, 0);
-                RenderOptions.SetBitmapScalingMode(img, BitmapScalingMode.NearestNeighbor);
-                SheetWrap.Children.Add(img);
+                
+                border.Child = img;
+                RenderOptions.SetBitmapScalingMode(border, BitmapScalingMode.NearestNeighbor);
+                SheetWrap.Children.Add(border);
             }
             SheetWrap.Width = SprSheetWidth + 1 + (SprSheetWidth / SpriteWidth);
             SheetWrap.Height = SprSheetHeight + 1 + (SprSheetHeight / SpriteHeight);
         }
 
-        private void Img_Drop(object sender, DragEventArgs e)
+        private void Border_MouseDown(object sender, MouseButtonEventArgs e)
         {
+            if (sender is not Border targetBorder) return;
+            if (e.LeftButton == MouseButtonState.Pressed)
+            {
+                DragDrop.DoDragDrop(targetBorder, targetBorder, DragDropEffects.Move);
+            }
+            
+        }
+
+        private void Border_MouseEnter(object sender, MouseEventArgs e)
+        {
+            if (sender is not Border targetBorder) return;
+            focusedIndex = (int)targetBorder.Tag;
+            ApplyBorderFocus(targetBorder);
+        }
+
+        private void Border_MouseLeave(object sender, MouseEventArgs e)
+        {
+            if (sender is not Border targetBorder) return;
+            RemoveBorderFocus(targetBorder);
+        }
+
+        private void Border_DragEnter(object sender, DragEventArgs e)
+        {
+            if (sender is not Border targetBorder) return;
             if (e.Data.GetDataPresent(DataFormats.FileDrop))
             {
                 string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
-                BitmapImage sourceBitmap = new BitmapImage(new Uri(files[0]));
-                List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
-                if (Math.Ceiling(sourceBitmap.Width) >= SprSheetWidth && Math.Ceiling(sourceBitmap.Height) >= SprSheetHeight)
+                if (files == null) return;
+            
+                int targetIndex = (int)targetBorder.Tag;
+                for (int i = 0; i < files.Length; i++)
                 {
-                    Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[0]), true);
-                    int sprCount = 0;
-                    int xCols = SpriteWidth == 32 ? 12 : 6;
-                    int yCols = SpriteHeight == 32 ? 12 : 6;
-                    for (int x = 0; x < yCols; x++)
+                    if (targetIndex + i < SheetWrap.Children.Count)
                     {
-                        for (int y = 0; y < xCols; y++)
+                        if (SheetWrap.Children[targetIndex + i] is Border border)
                         {
-                            Rectangle rect = new Rectangle(y * SpriteWidth, x * SpriteHeight, SpriteWidth, SpriteHeight);
-                            Bitmap crop = original.Clone(rect, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-                            images[sprCount].Source = Utils.BitmapToBitmapImage(crop);
-                            sprCount++;
+                            ApplyBorderFocus(border);
                         }
                     }
-
                 }
-                else
-                {
-                    if (files.Length > 1)
-                    {
-                        for (int i = 0; i < files.Length; i++)
-                        {
-                            Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[i]), true);
-                            images[i].Source = Utils.BitmapToBitmapImage(original);
-                        }
-                    }
-                    else
-                    {
-                        Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[0]), true);
-                        Image img = e.Source as Image;
-                        img.Source = Utils.BitmapToBitmapImage(original);
-                    }
-                }
-                EmptyTiles = false;
+            }
+            else if (e.Data.GetData(e.Data.GetFormats()[0]) is Border border)
+            {
+                ApplyBorderDragging(targetBorder);
+                ApplyBorderDragging(border);
             }
         }
 
-        private void Img_DragOverSheet(object sender, DragEventArgs e)
+        private void Border_DragLeave(object sender, DragEventArgs e)
         {
-            e.Effects = DragDropEffects.Copy;
+            ClearBorders();
         }
+
+        private void ApplyBorderFocus(Border border)
+        {
+            border.BorderBrush = new SolidColorBrush(Colors.Blue);
+            border.BorderThickness = new Thickness(3);
+        }
+        
+        private void ApplyBorderDragging(Border border)
+        {
+            border.BorderBrush = new SolidColorBrush(Colors.DarkGreen);
+            border.BorderThickness = new Thickness(3);
+        }
+
+        private void RemoveBorderFocus(Border border)
+        {
+            border.BorderBrush = new SolidColorBrush(Colors.Transparent);
+            border.BorderThickness = new Thickness(0);
+        }
+
+        private void ClearBorders()
+        {
+            foreach (var child in SheetWrap.Children)
+            {
+                if (child is Border border)
+                {
+                    RemoveBorderFocus(border);
+                }
+            }
+        }
+        
+        private void OnPaste(object sender, ExecutedRoutedEventArgs e)
+        {
+            if (Clipboard.ContainsFileDropList())
+            {
+                var files = Clipboard.GetFileDropList();
+                MakeFilesAsSprites(files.Cast<string>().ToArray(), focusedIndex, null);
+            }
+        }
+        
+        private void OnDelete(object sender, ExecutedRoutedEventArgs e)
+        {
+            List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
+            if (focusedIndex >= 0 && focusedIndex < images.Count)
+            {
+                images[focusedIndex].Source = emptyBitmapSource;
+            }
+        }
+
+        private void Border_Drop(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                var targetSpriteIndex = 0;
+                if (sender is Border border)
+                {
+                    targetSpriteIndex = (int)border.Tag;
+                }
+                
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                MakeFilesAsSprites(files, targetSpriteIndex, e);
+                
+                EmptyTiles = false;
+                ClearBorders();
+            } else if (e.Data.GetData(e.Data.GetFormats()[0]) is Border sourceBorder)
+            {
+                if (sender is Border targetBorder)
+                {
+                    var sourceImage = Utils.GetLogicalChildCollection<Image>(sourceBorder)[0];
+                    var targetImage = Utils.GetLogicalChildCollection<Image>(targetBorder)[0];
+                    (targetImage.Source, sourceImage.Source) = (sourceImage.Source, targetImage.Source);
+                }
+                ClearBorders();
+            }
+        }
+
+        private void MakeFilesAsSprites(string[] files, int targetImageIndex, DragEventArgs e)
+        {
+            BitmapImage sourceBitmap = new BitmapImage(new Uri(files[0]));
+            List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
+            if (Math.Ceiling(sourceBitmap.Width) >= SprSheetWidth &&
+                Math.Ceiling(sourceBitmap.Height) >= SprSheetHeight)
+            {
+                Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[0]), true);
+                int sprCount = targetImageIndex;
+                int xCols = SpriteWidth == 32 ? 12 : 6;
+                int yCols = SpriteHeight == 32 ? 12 : 6;
+                for (int x = 0; x < yCols; x++)
+                {
+                    for (int y = 0; y < xCols; y++)
+                    {
+                        Rectangle rect = new Rectangle(y * SpriteWidth, x * SpriteHeight, SpriteWidth, SpriteHeight);
+                        Bitmap crop = original.Clone(rect, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                        if (sprCount < images.Count)
+                        {
+                            images[sprCount].Source = Utils.BitmapToBitmapImage(crop);
+                        }
+
+                        sprCount++;
+                    }
+                }
+            }
+            else
+            {
+                if (files.Length > 1)
+                {
+                    for (int i = 0; i < files.Length; i++)
+                    {
+                        Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[i]), true);
+                        if (targetImageIndex + i < images.Count)
+                        {
+                            images[targetImageIndex + i].Source = Utils.BitmapToBitmapImage(original);
+                        }
+                    }
+                }
+                else
+                {
+                    Bitmap original = Utils.ConvertBackgroundToMagenta(new Bitmap(@files[0]), true);
+                    Image img = e.Source as Image;
+                    img.Source = Utils.BitmapToBitmapImage(original);
+                }
+            }
+        }
+
         private void NewSheetDialogHost_OnDialogClosing(object sender, DialogClosingEventArgs eventArgs)
         {
             if (!Equals(eventArgs.Parameter, true)) return;
@@ -323,7 +465,6 @@ namespace Assets_Editor
                     }
                 }
                 SprStatusBar.MessageQueue.Enqueue($"New sheet saved.", null, null, null, false, true, TimeSpan.FromSeconds(3));
-                _editor.SprListView.ItemsSource = null;
                 _editor.SprListView.ItemsSource = MainWindow.AllSprList;
             }
             else
@@ -335,27 +476,35 @@ namespace Assets_Editor
             if (SheetsList.SelectedIndex > -1)
             {               
                 ShowList showList = (ShowList)SheetsList.SelectedItem;
-                CurrentSheet = MainWindow.catalog.Find(x => x.File == showList.Name);
-                CreateNewSheetImg(CurrentSheet.SpriteType, true);
-                EmptyTiles = false;
-                List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
-                Bitmap original = Utils.BitmapImageToBitmap((BitmapImage)showList.Image);
+                if (showList == null)
+                    return;
+                EditSheetFor(showList);
+            }
+        }
 
-                int sprCount = 0;
-                int xCols = SpriteWidth == 32 ? 12 : 6;
-                int yCols = SpriteHeight == 32 ? 12 : 6;
-                for (int x = 0; x < yCols; x++)
+        private void EditSheetFor(ShowList showList)
+        {
+            CurrentSheet = MainWindow.catalog.Find(x => x.File == showList.Name);
+            CreateNewSheetImg(CurrentSheet.SpriteType, true);
+            EmptyTiles = false;
+            List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
+            Bitmap original = Utils.BitmapImageToBitmap((BitmapImage)showList.Image);
+
+            int sprCount = 0;
+            int xCols = SpriteWidth == 32 ? 12 : 6;
+            int yCols = SpriteHeight == 32 ? 12 : 6;
+            for (int x = 0; x < yCols; x++)
+            {
+                for (int y = 0; y < xCols; y++)
                 {
-                    for (int y = 0; y < xCols; y++)
-                    {
-                        Rectangle rect = new Rectangle(y * SpriteWidth, x * SpriteHeight, SpriteWidth, SpriteHeight);
-                        Bitmap crop = new Bitmap(SpriteWidth, SpriteHeight);
-                        crop = original.Clone(rect, crop.PixelFormat);
-                        images[sprCount].Source = Utils.BitmapToBitmapImage(crop);
-                        sprCount++;
-                    }
+                    Rectangle rect = new Rectangle(y * SpriteWidth, x * SpriteHeight, SpriteWidth, SpriteHeight);
+                    Bitmap crop = new Bitmap(SpriteWidth, SpriteHeight);
+                    crop = original.Clone(rect, crop.PixelFormat);
+                    images[sprCount].Source = Utils.BitmapToBitmapImage(crop);
+                    sprCount++;
                 }
             }
+            
         }
 
         private void CreateNewSheet_Click(object sender, RoutedEventArgs e)
@@ -402,6 +551,44 @@ namespace Assets_Editor
             }
             SheetsList.ItemsSource = SprEditor.CustomSheetsList;
 
+        }
+
+        public void OpenForSpriteId(int spriteId)
+        {
+            foreach (var catalog in MainWindow.catalog)
+            {
+                if (spriteId >= catalog.FirstSpriteid && spriteId <= catalog.LastSpriteid)
+                {
+                    string _sprPath = String.Format("{0}{1}", MainWindow._assetsPath, catalog.File);
+                    if (File.Exists(_sprPath))
+                    {
+                        ShowList foundEntry = SprEditor.CustomSheetsList.FirstOrDefault(showList => showList.Id == (uint)catalog.FirstSpriteid);
+                        if (foundEntry == null)
+                        {
+                            using System.Drawing.Bitmap SheetM = LZMA.DecompressFileLZMA(_sprPath);
+                            using Bitmap transparentBitmap = new Bitmap(SheetM.Width, SheetM.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                            using (Graphics g = Graphics.FromImage(transparentBitmap))
+                            {
+                                g.Clear(System.Drawing.Color.FromArgb(255, 255, 0, 255));
+                                g.DrawImage(SheetM, 0, 0);
+
+                            }
+
+                            SprEditor.CustomSheetsList.Add(new ShowList() { Id = (uint)catalog.FirstSpriteid, Image = Utils.BitmapToBitmapImage(transparentBitmap), Name = catalog.File });
+                        }
+
+                    }
+                }
+            }
+            SheetsList.ItemsSource = SprEditor.CustomSheetsList;
+            SheetsList.SelectedIndex = 0;
+            if (SheetsList.SelectedIndex > -1)
+            {
+                ShowList showList = (ShowList)SheetsList.SelectedItem;
+                if (showList == null)
+                    return;
+                EditSheetFor(showList);
+            }
         }
     }
 }

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -18,6 +18,7 @@ using System.Runtime.InteropServices;
 using Efundies;
 using System.Linq;
 using System.Windows.Controls;
+using System.Windows.Data;
 
 namespace Assets_Editor
 {
@@ -467,8 +468,7 @@ namespace Assets_Editor
                     }
                 }
                 SprStatusBar.MessageQueue.Enqueue($"New sheet saved.", null, null, null, false, true, TimeSpan.FromSeconds(3));
-                _editor.SprListView.ItemsSource = null;
-                _editor.SprListView.ItemsSource = MainWindow.AllSprList;
+                CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
             }
             else
                 SprStatusBar.MessageQueue.Enqueue($"Create a new sheet to import.", null, null, null, false, true, TimeSpan.FromSeconds(3));


### PR DESCRIPTION
## Dat Editor:

* Sprite List context menu for each sprite to open a dedicated spritesheet to edit. (Note: I am no WPF or C# expert, but for some reason by adding a context menu it overrode the default styles for each item. I don't know how to style them again, so I left them as they are, since they look somewhat ok).

  ![obraz](https://github.com/Arch-Mina/Assets-Editor/assets/10242142/11ad337d-f959-43f9-a839-3638214d2a40)

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/379ff512-1235-4242-911a-266a2b763ca3

## Sprite Editor:

* Remove magnifying glass for a Current Sheet Viewer.
* The default empty sprite is magenta. Previously was white.
* Drag and dropping multiple files now puts them at the place of the cursor. Previously they all were placed at the beginning.

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/b84144e2-5729-44e6-8a76-8cbb486000d4

* Allow pasting multiple files. They are placed at the position of a cursor.

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/b65531c3-f55e-4aca-930e-1ac2935cc528

* Reorder sprites by dragging them over another.

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/df673d60-25c8-4304-81dc-7b24fc7388fb

* Remove a sprite the cursor is currently over by pressing "Del".

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/26e682ee-4bca-47ab-acb0-e24dc18f4056

## Misc:

* Update to .NET 8.
* Remove "Exit" option in the "File" Submenu. I accidentally clicked it multiple times instead of "Compile" action below and it exited the program without saving my progress.
* Fix scroll reset everywhere. When adding sprites to a ListView the list was set to null first, ten again to a list of sprites. This resetted a scroll position.
```c#
// before
_editor.SprListView.ItemsSource = null;
_editor.SprListView.ItemsSource = MainWindow.AllSprList;

// after
CollectionViewSource.GetDefaultView(_editor.SprListView.ItemsSource).Refresh();
```