### PR TITLE
Dat Editor Improvements

### DIFF
--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -564,6 +564,7 @@
                               VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.IsVirtualizing="True"
                               SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               ScrollViewer.ScrollChanged="SprListView_ScrollChanged" MouseMove="SprListView_DragSpr"
+                              PreviewMouseLeftButtonDown="SprListView_PreviewMouseLeftButtonDown"
                               SelectedIndex="0" Width="207">
                         <ListView.Resources>
                             <ContextMenu x:Key="RowContextMenu">

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -447,6 +447,10 @@
                                                     <Label Content="Loop Count:" Width="120"/>
                                                     <xctk:IntegerUpDown x:Name="SprLoopCount" Minimum="0" Maximum="1000" HorizontalAlignment="Left" Width="110" ValueChanged="SprLoopCount_ValueChanged"/>
                                                 </StackPanel>
+                                            </StackPanel>
+                                        </GroupBox>
+                                        <GroupBox x:Name="SpriteFrameAnimationGroup" Header="Frame Animation" VerticalAlignment="Top" HorizontalAlignment="Left" Width="320" Margin="0,10,0,0">
+                                            <StackPanel Orientation="Vertical" x:Name="SpriteFrameAnimationTab" HorizontalAlignment="Center" VerticalAlignment="Stretch">
                                                 <StackPanel Orientation="Horizontal">
                                                     <Label Content="Min Duration:" Width="120"/>
                                                     <xctk:IntegerUpDown x:Name="SprPhaseMin" Width="110" Minimum="0" Maximum="1000" ValueChanged="SprPhaseMin_ValueChanged"/>
@@ -455,6 +459,13 @@
                                                     <Label Content="Max Duration:" Width="120"/>
                                                     <xctk:IntegerUpDown x:Name="SprPhaseMax" Width="110" Minimum="0" Maximum="1000" ValueChanged="SprPhaseMax_ValueChanged"/>
                                                 </StackPanel>
+                                                <Grid Margin="0,5,0,0">
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="Auto" />
+                                                    </Grid.ColumnDefinitions>
+                                                    <Button x:Name="SprApplyForAll" Content="Apply to all frames" Grid.Column="1"  Click="SprApplyForAll_Click"/>
+                                                </Grid>
                                             </StackPanel>
                                         </GroupBox>
                                         <StackPanel>
@@ -471,7 +482,7 @@
                                             <CheckBox x:Name="SprMount" Content="Mount" Height="20" Width="100" Click="SprMount_Click" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="0,5,0,0" />
                                         </StackPanel>
                                     </StackPanel>
-                                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,30,5,0" Width="320">
+                                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Margin="5,5,5,0" Width="320">
                                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Height="20" Margin="0,5,0,0">
                                             <Label Content="Groups:" Width="120" Padding="0,0,0,0" Margin="10,0,0,0" HorizontalAlignment="Left"/>
                                             <xctk:IntegerUpDown x:Name="A_SprGroups" Margin="0,0,0,0" Width="110" Minimum="1" Maximum="2" ValueChanged="A_Texture_ValueChanged" />

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -550,6 +550,13 @@
                         <StackPanel Orientation="Horizontal">
                             <materialDesign:PackIcon Kind="ImageArea" Height="32" Width="32" VerticalAlignment="Center" />
                             <TextBlock Margin="8,0,0,0" VerticalAlignment="Center" Style="{StaticResource MaterialDesignSubtitle1TextBlock}" Text="{Binding}" />
+                            <Button x:Name="SpriteListHelp" Style="{StaticResource MaterialDesignFlatAccentButton}"
+                                    ToolTip="Help" materialDesign:RippleAssist.IsDisabled="True"
+                                    Margin="20,0,0,0"
+                                    PreviewMouseLeftButtonDown="SpriteListHelp_PreviewMouseLeftButtonDown"
+                                    Content="{materialDesign:PackIcon HelpCircle}"
+                                    HorizontalAlignment="Right" VerticalAlignment="Center">
+                            </Button>
                         </StackPanel>
                     </DataTemplate>
                 </GroupBox.HeaderTemplate>

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -421,8 +421,14 @@
                                             </Button>
                                         </Grid>
                                         <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                                            <Label x:Name="SprFramesSliderCounter" HorizontalAlignment="Left" Margin="20,0,0,0" VerticalAlignment="Top" HorizontalContentAlignment="Left" Content="{Binding Value, ElementName=SprFramesSlider, Converter={StaticResource ArithmeticConverter}, ConverterParameter=1}"/>
-                                            <Slider x:Name="SprFramesSlider" Width="170" IsSnapToTickEnabled="True" TickFrequency="1" ValueChanged="SprFramesSlider_ValueChanged" Margin="35,5,0,0" SmallChange="1" VerticalAlignment="Top" HorizontalAlignment="Left"/>
+                                            <Label x:Name="SprFramesSliderCounter" HorizontalAlignment="Left"
+                                                   Margin="20,0,0,0" VerticalAlignment="Top"
+                                                   MinWidth="40" HorizontalContentAlignment="Left"
+                                                   Content="{Binding Value, ElementName=SprFramesSlider, Converter={StaticResource ArithmeticConverter}, ConverterParameter=1}" />
+                                            <Slider x:Name="SprFramesSlider" Width="170" IsSnapToTickEnabled="True"
+                                                    TickFrequency="1" ValueChanged="SprFramesSlider_ValueChanged"
+                                                    Margin="35,5,0,0" SmallChange="1" VerticalAlignment="Top"
+                                                    HorizontalAlignment="Left" />
                                         </StackPanel>
                                         <xctk:ColorPicker x:Name="SprBackgroundPicker" VerticalAlignment="Top" AdvancedTabHeader="False" ShowTabHeaders="False" SelectedColor="Gray" Width="200" Margin="0,15,0,10"/>
                                     </StackPanel>

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -2124,8 +2124,8 @@ namespace Assets_Editor
         {
             const string message =
                 "You can drag and drop a single or multiple sprites at once onto a Texture. \n" +
-                "Normal dragging fills the current Texture's frame. \n" +
-                "Ctrl dragging fills all the frames.";
+                "Normal dragging - treats sprites as elements of the current frame. \n" +
+                "Ctrl dragging - treats sprites as a sequence of frames.";
             MessageBox.Show(message, "Sprite List Help", MessageBoxButton.OK, MessageBoxImage.Information);
         }
     }

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -315,6 +315,7 @@ namespace Assets_Editor
             ForceSliderChange();
             SprFramesSlider.Maximum = (double)A_SprAnimation.Value - 1;
             AnimationTab.IsEnabled = CurrentObjectAppearance.FrameGroup[group].SpriteInfo.Animation != null;
+            SpriteFrameAnimationTab.IsEnabled = CurrentObjectAppearance.FrameGroup[group].SpriteInfo.Animation != null;
             if (A_SprAnimation.Value > 1)
             {
                 SprDefaultPhase.Value = CurrentObjectAppearance.FrameGroup[group].SpriteInfo.Animation.HasDefaultStartPhase ? (int)CurrentObjectAppearance.FrameGroup[group].SpriteInfo.Animation.DefaultStartPhase : 0;
@@ -777,7 +778,8 @@ namespace Assets_Editor
                 }
 
                 FixSpritesCount();
-                SpriteAnimationGroup.IsEnabled = A_SprAnimation.Value > 1 ? true : false;
+                SpriteAnimationGroup.IsEnabled = A_SprAnimation.Value > 1;
+                SpriteFrameAnimationGroup.IsEnabled = A_SprAnimation.Value > 1;
                 SprFramesSlider.Maximum = (double)A_SprAnimation.Value - 1;
             }
         }
@@ -2028,6 +2030,24 @@ namespace Assets_Editor
             SprEditor.CustomSheetsList.Clear();
             sprEditor.Show();
             sprEditor.OpenForSpriteId((int)showList.Id);
+        }
+
+        private void SprApplyForAll_Click(object sender, RoutedEventArgs e)
+        {
+            if (CurrentObjectAppearance.FrameGroup[(int)SprGroupSlider.Value].SpriteInfo.Animation == null) return;
+
+            var minDuration = (uint)SprPhaseMin.Value;
+            var maxDuration = (uint)SprPhaseMax.Value;
+            var animationSpritePhases = CurrentObjectAppearance.FrameGroup[(int)SprGroupSlider.Value].SpriteInfo
+                .Animation.SpritePhase;
+            
+            foreach (var spritePhase in animationSpritePhases)
+            {
+                spritePhase.DurationMin = minDuration;
+                spritePhase.DurationMax = maxDuration;
+            }
+            
+            StatusBar.MessageQueue.Enqueue($"Successfully applied to {animationSpritePhases.Count} frames.", null, null, null, false, true, TimeSpan.FromSeconds(3));
         }
     }
 }

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -2088,5 +2088,14 @@ namespace Assets_Editor
             
             StatusBar.MessageQueue.Enqueue($"Successfully applied to {animationSpritePhases.Count} frames.", null, null, null, false, true, TimeSpan.FromSeconds(3));
         }
+
+        private void SpriteListHelp_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            const string message =
+                "You can drag and drop a single or multiple sprites at once onto a Texture. \n" +
+                "Normal dragging fills the current Texture's frame. \n" +
+                "Ctrl dragging fills all the frames.";
+            MessageBox.Show(message, "Sprite List Help", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
     }
 }

--- a/Assets Editor/Utils.cs
+++ b/Assets Editor/Utils.cs
@@ -46,6 +46,10 @@ namespace Assets_Editor
 
         public static BitmapImage BitmapToBitmapImage(MemoryStream stream)
         {
+            if (stream == null)
+            {
+                return null;
+            }
             BitmapImage bitmap = new BitmapImage();
             bitmap.BeginInit();
             stream.Seek(0, System.IO.SeekOrigin.Begin);


### PR DESCRIPTION
# Dat Editor

* Move Duration settings into a dedicated section. They are separate for each frame, whereas the rest of Animation config is for the entire texture.

  ![obraz](https://github.com/Arch-Mina/Assets-Editor/assets/10242142/9100d8ee-542c-479a-9195-6eadc2e9471c)

* Add "Apply to all frames" button to apply duration to all the frames. Previously if you had 50 frames and wanted to change duration to all of them you had to go manually to each frame and set the duration.

  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/e407a34b-0b6f-4ce6-8140-959e3c40b2b6

* Add Sprite List help button

  ![obraz](https://github.com/Arch-Mina/Assets-Editor/assets/10242142/c90ff1d0-b891-4eb3-9775-a87e47093eff)

* Allow dragging multiple sprites onto a texture. Previously you could do only 1 at a time


  https://github.com/Arch-Mina/Assets-Editor/assets/10242142/9a2aa761-1ab4-432c-93e5-e595de2f1dc9

* Allow dragging multiple sprites with Ctrl key onto a texture. This will treat selected sprites as a sequence of frames.

https://github.com/Arch-Mina/Assets-Editor/assets/10242142/51b8c67e-ceda-45a9-ba40-d94126c864a0





