### PR TITLE
Dat Editor improvements

### DIFF
--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -607,7 +607,6 @@
                               VirtualizingPanel.VirtualizationMode="Recycling" VirtualizingPanel.IsVirtualizing="True"
                               SelectionMode="Extended" ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                               ScrollViewer.ScrollChanged="SprListView_ScrollChanged" MouseMove="SprListView_DragSpr"
-                              PreviewMouseLeftButtonDown="SprListView_PreviewMouseLeftButtonDown"
                               SelectedIndex="0" Width="207">
                         <ListView.Resources>
                             <ContextMenu x:Key="RowContextMenu">

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -682,8 +682,11 @@ namespace Assets_Editor
                     img.ToolTip = dataItem.Id.ToString();
                     CurrentObjectAppearance.FrameGroup[(int)SprGroupSlider.Value].SpriteInfo.SpriteId[(int)img.Tag] =
                         dataItem.Id;
-                    maxSpriteWidth = Math.Max(maxSpriteWidth, (int)dataItem.Image.Width);
-                    maxSpriteHeight = Math.Max(maxSpriteHeight, (int)dataItem.Image.Height);
+                    if (dataItem.Image is not null)
+                    {
+                        maxSpriteWidth = Math.Max(maxSpriteWidth, (int)dataItem.Image.Width);
+                        maxSpriteHeight = Math.Max(maxSpriteHeight, (int)dataItem.Image.Height);
+                    }
                 }
 
 

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -109,6 +109,7 @@ namespace Assets_Editor
                 ThingsMissile.Add(new ShowList() { Id = missile.Id});
             }
             SprListView.ItemsSource = MainWindow.AllSprList;
+            SprListView.AddHandler(MouseLeftButtonDownEvent, new MouseButtonEventHandler(SprListView_MouseLeftButtonDown), true);
             UpdateShowList(ObjectMenu.SelectedIndex);
         }
         private void UpdateShowList(int selection)
@@ -177,7 +178,7 @@ namespace Assets_Editor
             return null;
         }
         
-        private void SprListView_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        private void SprListView_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {
             SelectedSprites = SprListView.SelectedItems.Cast<ShowList>().ToList();
         }


### PR DESCRIPTION
* [Fix NPE if there is no sprite image](https://github.com/Arch-Mina/Assets-Editor/commit/8d66b0a51b3f4a253d8622991d67fb8c24004eb0)
* [Fix sprite selection being always 1 click behind](https://github.com/Arch-Mina/Assets-Editor/commit/9db59ca66e52b281d3c9d5b4264b6ee171ddcdc9)
  PreviewMouseLeftButtonDown event is always invoked before the item is added to select list.