### PR TITLE
fix: MainWindow not shutting down program when exited

### DIFF
--- a/Assets Editor/MainWindow.xaml.cs
+++ b/Assets Editor/MainWindow.xaml.cs
@@ -50,6 +50,12 @@ namespace Assets_Editor
             };
         }
 
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            System.Windows.Application.Current.Shutdown();
+        }
+
         public class Catalog
         {
             public Catalog()


### PR DESCRIPTION
Currently, when exiting the program while at the MainWindow to select your assets files or .dat/.spr, the program was not exiting and would still run in the background. This will close the program when you press the exit button while at the MainWindow.