### PR TITLE
fix image generator when used as img src

### DIFF
--- a/Assets Editor/images_generator/common.php
+++ b/Assets Editor/images_generator/common.php
@@ -28,6 +28,7 @@
 	// Block sites that hotlink your host and overload it
 	// see config.php for configuration
 	function is_abuser($referer) {
+		global $abusersList;
 		return in_array(parse_url($referer, PHP_URL_HOST), $abusersList)
 			|| in_array(substr(parse_url($referer, PHP_URL_HOST), 4), $abusersList);
 	}


### PR DESCRIPTION
this fixes an issue with the image failing to load when included this way:
`<img src="img/outfit.php?type=128"/>`