### PR TITLE
fix: "bounding box per direction" box and "Bouding square" save problem in Textures.

### DIFF
--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -1072,6 +1072,8 @@ namespace Assets_Editor
 
         private void ObjectSave_PreviewMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
         {
+            BoxPerDirection.CommitEdit(DataGridEditingUnit.Cell, true);  
+            BoxPerDirection.CommitEdit(DataGridEditingUnit.Row, true);
             if (!string.IsNullOrWhiteSpace(A_FlagName.Text))
                 CurrentObjectAppearance.Name = A_FlagName.Text;
 

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -1074,6 +1074,14 @@ namespace Assets_Editor
         {
             BoxPerDirection.CommitEdit(DataGridEditingUnit.Cell, true);  
             BoxPerDirection.CommitEdit(DataGridEditingUnit.Row, true);
+            if (A_SprBounding.Value.HasValue)  
+            {  
+                CurrentObjectAppearance.FrameGroup[(int)SprGroupSlider.Value].SpriteInfo.BoundingSquare = (uint)A_SprBounding.Value.Value;  
+            }  
+            else  
+            {  
+                CurrentObjectAppearance.FrameGroup[(int)SprGroupSlider.Value].SpriteInfo.ClearBoundingSquare();  
+            }
             if (!string.IsNullOrWhiteSpace(A_FlagName.Text))
                 CurrentObjectAppearance.Name = A_FlagName.Text;
 


### PR DESCRIPTION
BoxPerDirection.CommitEdit(DataGridEditingUnit.Cell, true): Forces the commit of the cell that is currently being edited

BoxPerDirection.CommitEdit(DataGridEditingUnit.Row, true): Forces the commit of the entire row containing the edited cell