### PR TITLE
fix a range bug with creating a new spritesheet

### DIFF
--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -462,7 +462,7 @@ namespace Assets_Editor
 
                 if (CurrentSheet == null)
                 {
-                    for (int i = sprInfo.FirstSpriteid; i < sprInfo.LastSpriteid; i++)
+                    for (int i = sprInfo.FirstSpriteid; i <= sprInfo.LastSpriteid; i++)
                     {
                         AllSprList.Add(new ShowList() { Id = (uint)i });
                     }

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -400,7 +400,7 @@ namespace Assets_Editor
                     File = "",
                     SpriteType = SprType,
                     FirstSpriteid = AllSprList.Count,
-                    LastSpriteid = AllSprList.Count + images.Count,
+                    LastSpriteid = AllSprList.Count + images.Count - 1,
                     Area = 0
                 };
 


### PR DESCRIPTION
### Bug description
- When creating a new spritesheet, there is one sprite too much.
- If you fill the spritesheet entirely and save, you may end up with a glitched sprite that cannot be edited

<img width="336" height="312" alt="obraz" src="https://github.com/user-attachments/assets/6821f148-197a-47d5-ac7b-8d0294736010" />

### How the function currently works
existing sprites are in range `0 <-> (n-1)`
`AllSprList.Count` returns `n`, which is correct `FirstSpriteId` for the new sheet

Now for a sheet with 64x64 sprites, there are 36 images, but the `FirstSpriteId` is already the first image
and `images.Count` is `36`
so `n+36` results in `LastSpriteId` being one number too large

The distance from `firstSpriteId` to `lastSpriteId` should be `35` in this case, not `36`
This PR fixes that bug.

I recommend testing before merging that because this code is delicate and I don't have full confidence in my change not breaking anything.