### PR TITLE
fix crash on deleted appearance

### DIFF
--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -358,6 +358,10 @@ namespace Assets_Editor
 
         private void LoadSelectedObjectAppearances(Appearance ObjectAppearance)
         {
+            if (ObjectAppearance == null)
+            {
+                return;
+            }
             CurrentObjectAppearance = ObjectAppearance.Clone();
             LoadCurrentObjectAppearances();
             SprGroupSlider.ValueChanged -= SprGroupSlider_ValueChanged;
@@ -2463,6 +2467,7 @@ namespace Assets_Editor
                 }
                 ObjListView.SelectedIndex = Math.Min(currentIndex, ObjListView.Items.Count - 1);
                 StatusBar.MessageQueue.Enqueue($"Successfully deleted {selectedItems.Count} {(selectedItems.Count == 1 ? "object" : "objects")}.", null, null, null, false, true, TimeSpan.FromSeconds(2));
+                UpdateShowList(ObjectMenu.SelectedIndex);
             }
         }
 
@@ -3029,6 +3034,11 @@ namespace Assets_Editor
                     {
                         appearance = MainWindow.appearances.Missile.FirstOrDefault(o => o.Id == showList.Id);
                         exported = exportObjects.Missile.Any(a => a.Id == appearance.Id);
+                    }
+
+                    if (appearance == null)
+                    {
+                        return;
                     }
 
                     try


### PR DESCRIPTION
Fix a crash when trying to access data for a deleted appearance (null)

The crash happened when you delete an appearance. The showlist is not updated, so when you scroll or click on the deleted appearance (now null) the application crashes.

Added null checks and list update to avoid these scenarios.