### PR TITLE
feat: Sprite Sheet Slicer

### DIFF
--- a/Assets Editor/SprEditor.xaml
+++ b/Assets Editor/SprEditor.xaml
@@ -50,6 +50,9 @@
                         <Button x:Name="ExportSheet" Style="{StaticResource MaterialDesignIconButton}" ToolTip="Export Sheet" materialDesign:RippleAssist.IsDisabled="True" PreviewMouseLeftButtonDown="ExportSheet_PreviewMouseLeftButtonDown" HorizontalAlignment="Left" VerticalAlignment="Center">
                             <materialDesign:PackIcon Kind="ContentSaveMove" Width="25" Height="25"/>
                         </Button>
+                        <Button x:Name="OpenSlicer" Style="{StaticResource MaterialDesignIconButton}" ToolTip="Open Sprite Sheet Slicer" materialDesign:RippleAssist.IsDisabled="True" Click="OpenSlicer_Click" HorizontalAlignment="Left" VerticalAlignment="Center">
+                            <materialDesign:PackIcon Kind="Scissors" Width="25" Height="25"/>
+                        </Button>
                     </StackPanel>
                 </Border>
                 <materialDesign:Snackbar x:Name="SprStatusBar" MessageQueue="{materialDesign:MessageQueue}" IsActive="False" HorizontalAlignment="Stretch" Margin="10,10,10,0" VerticalAlignment="Top" Height="30" HorizontalContentAlignment="Center" VerticalContentAlignment="Center" ScrollViewer.VerticalScrollBarVisibility="Disabled" Padding="0,-20,0,0" />

--- a/Assets Editor/SprEditor.xaml.cs
+++ b/Assets Editor/SprEditor.xaml.cs
@@ -55,6 +55,7 @@ namespace Assets_Editor
         private BitmapSource emptyBitmapSource;
         public static ObservableCollection<ShowList> CustomSheetsList = new ObservableCollection<ShowList>();
         private Catalog CurrentSheet = null;
+        private SpriteSlicerWindow _slicerWindow = null;
         private void CreateNewSheetImg(int sprType, bool modify)
         {
             EmptyTiles = true;
@@ -142,7 +143,7 @@ namespace Assets_Editor
             {
                 string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
                 if (files == null) return;
-            
+
                 int targetIndex = (int)targetBorder.Tag;
                 for (int i = 0; i < files.Length; i++)
                 {
@@ -152,6 +153,18 @@ namespace Assets_Editor
                         {
                             ApplyBorderFocus(border);
                         }
+                    }
+                }
+            }
+            else if (e.Data.GetData(typeof(SlicedSpritesDragData)) is SlicedSpritesDragData slicedData)
+            {
+                int targetIndex = (int)targetBorder.Tag;
+                for (int i = 0; i < slicedData.Images.Count; i++)
+                {
+                    if (targetIndex + i < SheetWrap.Children.Count)
+                    {
+                        if (SheetWrap.Children[targetIndex + i] is Border border)
+                            ApplyBorderFocus(border);
                     }
                 }
             }
@@ -224,13 +237,33 @@ namespace Assets_Editor
                 {
                     targetSpriteIndex = (int)border.Tag;
                 }
-                
+
                 string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
                 MakeFilesAsSprites(files, targetSpriteIndex, e);
-                
+
                 EmptyTiles = false;
                 ClearBorders();
-            } else if (e.Data.GetData(e.Data.GetFormats()[0]) is Border sourceBorder)
+            }
+            else if (e.Data.GetData(typeof(SlicedSpritesDragData)) is SlicedSpritesDragData slicedData)
+            {
+                if (sender is Border targetBorder)
+                {
+                    int startPos = (int)targetBorder.Tag;
+                    List<Image> images = Utils.GetLogicalChildCollection<Image>(SheetWrap);
+                    int placed = 0;
+                    for (int i = 0; i < slicedData.Images.Count && startPos + i < images.Count; i++)
+                    {
+                        images[startPos + i].Source = slicedData.Images[i];
+                        placed++;
+                    }
+                    EmptyTiles = false;
+                    ClearBorders();
+                    if (placed > 0)
+                        slicedData.SourceWindow.RemovePlacedSprites(slicedData.StartIndex, placed);
+                    SprStatusBar.MessageQueue?.Enqueue($"{placed} sprite(s) inserted from position {startPos}.", null, null, null, false, true, TimeSpan.FromSeconds(3));
+                }
+            }
+            else if (e.Data.GetData(e.Data.GetFormats()[0]) is Border sourceBorder)
             {
                 if (sender is Border targetBorder)
                 {
@@ -582,6 +615,20 @@ namespace Assets_Editor
         private void CreateSheet_Click(object sender, RoutedEventArgs e)
         {
             NewSheetDialogHost.IsOpen = true;
+        }
+
+        private void OpenSlicer_Click(object sender, RoutedEventArgs e)
+        {
+            if (_slicerWindow == null || !_slicerWindow.IsLoaded)
+            {
+                _slicerWindow = new SpriteSlicerWindow(SprType);
+                _slicerWindow.Owner = this;
+                _slicerWindow.Show();
+            }
+            else
+            {
+                _slicerWindow.Activate();
+            }
         }
 
         private void SearchSpr_Click(object sender, RoutedEventArgs e)

--- a/Assets Editor/SpriteSlicerWindow.xaml
+++ b/Assets Editor/SpriteSlicerWindow.xaml
@@ -1,0 +1,148 @@
+<Window x:Class="Assets_Editor.SpriteSlicerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        mc:Ignorable="d"
+        Title="Sprite Sheet Slicer" Height="720" Width="900"
+        Style="{StaticResource MaterialDesignWindow}">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Source import area -->
+        <GroupBox Grid.Row="0" Header="Source Sprite Sheet" Margin="0,0,0,6">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="220"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Drop zone / preview with grid overlay canvas -->
+                <Border Grid.Column="0"
+                        x:Name="DropZone"
+                        BorderBrush="#FF673AB7"
+                        BorderThickness="2"
+                        Background="#22673AB7"
+                        MinHeight="200" MaxHeight="340"
+                        AllowDrop="True"
+                        SizeChanged="DropZone_SizeChanged"
+                        DragEnter="DropZone_DragEnter"
+                        DragLeave="DropZone_DragLeave"
+                        Drop="DropZone_Drop"
+                        Margin="0,5,10,5"
+                        ClipToBounds="True">
+                    <!-- ScrollViewer enables panning when zoomed in -->
+                    <ScrollViewer x:Name="PreviewScrollViewer"
+                                  HorizontalScrollBarVisibility="Auto"
+                                  VerticalScrollBarVisibility="Auto"
+                                  PreviewMouseWheel="PreviewScrollViewer_PreviewMouseWheel"
+                                  PreviewMouseLeftButtonDown="PreviewScrollViewer_PreviewMouseLeftButtonDown"
+                                  PreviewMouseMove="PreviewScrollViewer_PreviewMouseMove"
+                                  PreviewMouseLeftButtonUp="PreviewScrollViewer_PreviewMouseLeftButtonUp"
+                                  PanningMode="None">
+                        <!-- PreviewContainer size is set from code-behind so Stretch=Uniform works inside an unconstrained ScrollViewer -->
+                        <Grid x:Name="PreviewContainer">
+                            <Grid.LayoutTransform>
+                                <ScaleTransform x:Name="PreviewScale" ScaleX="1" ScaleY="1"/>
+                            </Grid.LayoutTransform>
+                            <TextBlock x:Name="DropHint"
+                                       Text="Drop a sprite sheet here, or click Open File"
+                                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                                       Foreground="Gray" FontSize="13"/>
+                            <Image x:Name="SourcePreview"
+                                   Stretch="Uniform"
+                                   RenderOptions.BitmapScalingMode="NearestNeighbor"
+                                   Visibility="Collapsed"/>
+                            <!-- Grid lines drawn in code-behind; must sit above the image -->
+                            <Canvas x:Name="GridOverlay" IsHitTestVisible="False" Visibility="Collapsed"/>
+                            <!-- Zoom level badge shown in top-right when zoomed -->
+                            <Border x:Name="ZoomBadge"
+                                    Background="#CC000000" CornerRadius="3"
+                                    Padding="4,1" Margin="4"
+                                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                                    Visibility="Collapsed">
+                                <TextBlock x:Name="ZoomLabel" Text="100%"
+                                           Foreground="White" FontSize="10"/>
+                            </Border>
+                        </Grid>
+                    </ScrollViewer>
+                </Border>
+
+                <!-- Settings panel -->
+                <StackPanel Grid.Column="1" VerticalAlignment="Top" Margin="0,5,0,5">
+                    <Button Content="Open File" Click="OpenFile_Click" Margin="0,0,0,12"
+                            Style="{StaticResource MaterialDesignOutlinedButton}"/>
+
+                    <TextBlock Text="Sprite Size:" Margin="0,0,0,3"/>
+                    <ComboBox x:Name="SpriteSizeCombo" Margin="0,0,0,12" SelectedIndex="0"
+                              SelectionChanged="SpriteSizeCombo_SelectionChanged"/>
+
+                    <TextBlock Text="X Offset (pixels):" Margin="0,0,0,3"/>
+                    <xctk:IntegerUpDown x:Name="XOffset" Minimum="0" Maximum="383" Value="0"
+                                        Background="{DynamicResource MaterialDesignLightSeparatorBackground}"
+                                        Margin="0,0,0,12"
+                                        ValueChanged="Offset_ValueChanged"/>
+
+                    <TextBlock Text="Y Offset (pixels):" Margin="0,0,0,3"/>
+                    <xctk:IntegerUpDown x:Name="YOffset" Minimum="0" Maximum="383" Value="0"
+                                        Background="{DynamicResource MaterialDesignLightSeparatorBackground}"
+                                        Margin="0,0,0,16"
+                                        ValueChanged="Offset_ValueChanged"/>
+
+                    <Button Content="Slice" Click="Slice_Click"
+                            Background="#FF673AB7" BorderBrush="#FF673AB7"
+                            Foreground="White"
+                            Style="{StaticResource MaterialDesignRaisedButton}"/>
+
+                    <Button Content="Clear Slices" Click="ClearSlices_Click" Margin="0,8,0,0"
+                            Style="{StaticResource MaterialDesignOutlinedButton}"/>
+
+                    <CheckBox x:Name="HideGridLinesCheck"
+                              Content="Hide grid lines"
+                              Margin="0,12,0,0"
+                              Checked="HideGridLinesCheck_Changed"
+                              Unchecked="HideGridLinesCheck_Changed"/>
+                </StackPanel>
+            </Grid>
+        </GroupBox>
+
+        <!-- Status bar -->
+        <materialDesign:Snackbar Grid.Row="1"
+                                  x:Name="SlicerStatusBar"
+                                  MessageQueue="{materialDesign:MessageQueue}"
+                                  IsActive="False"
+                                  HorizontalAlignment="Stretch"
+                                  Height="30"
+                                  Padding="0,-20,0,0"
+                                  Margin="0,0,0,4"/>
+
+        <!-- Sliced sprites output -->
+        <GroupBox Grid.Row="2">
+            <GroupBox.Header>
+                <StackPanel Orientation="Horizontal">
+                    <TextBlock Text="Sliced Sprites - " VerticalAlignment="Center"/>
+                    <TextBlock x:Name="SliceCountLabel" Text="0 sprites" VerticalAlignment="Center"/>
+                    <TextBlock Text=" - Drag a tile onto a sheet slot to insert from that position"
+                               VerticalAlignment="Center" Foreground="Gray" FontSize="11"/>
+                    <TextBlock Text="   Tile Size:" VerticalAlignment="Center" Margin="10,0,5,0" FontSize="11"/>
+                    <Slider x:Name="TileZoomSlider"
+                            Minimum="0.5" Maximum="4" Value="1" Width="80"
+                            VerticalAlignment="Center" SmallChange="0.25" LargeChange="0.5"
+                            ValueChanged="TileZoomSlider_ValueChanged"/>
+                    <TextBlock x:Name="TileZoomLabel" Text="1.0x"
+                               VerticalAlignment="Center" Margin="4,0,0,0" FontSize="11" Width="30"/>
+                </StackPanel>
+            </GroupBox.Header>
+            <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                          VerticalScrollBarVisibility="Auto">
+                <WrapPanel x:Name="SlicedSpritesPanel" Background="#FFEAEAEA" Margin="2"/>
+            </ScrollViewer>
+        </GroupBox>
+    </Grid>
+</Window>

--- a/Assets Editor/SpriteSlicerWindow.xaml.cs
+++ b/Assets Editor/SpriteSlicerWindow.xaml.cs
@@ -1,0 +1,656 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using DrawingColor = System.Drawing.Color;
+using DrawingRect  = System.Drawing.Rectangle;
+using WpfLine      = System.Windows.Shapes.Line;
+using WpfRect      = System.Windows.Shapes.Rectangle;
+using WpfBrushes   = System.Windows.Media.Brushes;
+using WpfColor     = System.Windows.Media.Color;
+using Image        = System.Windows.Controls.Image;
+
+namespace Assets_Editor
+{
+    /// <summary>
+    /// Slices an external sprite sheet into individual tiles that can be dragged
+    /// onto any managed sheet in <see cref="SprEditor"/>.
+    /// </summary>
+    public partial class SpriteSlicerWindow : Window
+    {
+        private Bitmap _sourceBitmap;
+        private readonly List<BitmapSource> _slicedSprites = new();
+        private int _currentSprW = 32;
+        private int _currentSprH = 32;
+        private double _previewZoom = 1.0;
+        private double _tileZoomFactor = 1.0;
+        private bool _isDraggingPreview;
+        private System.Windows.Point _dragStartPos;
+        private double _dragStartScrollH;
+        private double _dragStartScrollV;
+
+        public SpriteSlicerWindow(int defaultSpriteTypeIndex = 0)
+        {
+            InitializeComponent();
+
+            SpriteSizeCombo.ItemsSource = DatEditor.SpriteSizes
+                .Select(s =>
+                {
+                    string label = $"Width: {s.Width} | Height: {s.Height} ({s.Width / 32}x{s.Height / 32}";
+                    if (s.Width > 64 || s.Height > 64)
+                        label += ", OTClient";
+                    label += ")";
+                    return label;
+                })
+                .ToList();
+            SpriteSizeCombo.SelectedIndex =
+                Math.Clamp(defaultSpriteTypeIndex, 0, DatEditor.SpriteSizes.Count - 1);
+        }
+
+        // file / drop zone 
+
+        private void OpenFile_Click(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog
+            {
+                Filter = "Image Files|*.png;*.bmp;*.gif;*.jpg;*.jpeg|All Files|*.*"
+            };
+            if (dlg.ShowDialog() == true)
+                LoadSourceImage(dlg.FileName);
+        }
+
+        private async void LoadSourceImage(string path)
+        {
+            _sourceBitmap?.Dispose();
+            _sourceBitmap = null;
+            SourcePreview.Visibility = Visibility.Collapsed;
+            DropHint.Text = "Loading…";
+            DropHint.Visibility = Visibility.Visible;
+
+            try
+            {
+                // Read bytes and do ALL image decoding on a background thread.
+                // Using StreamSource (not UriSource) lets BitmapImage be created and
+                // EndInit()'d on a thread-pool thread without needing a Dispatcher.
+                (BitmapImage preview, Bitmap fullBmp) = await Task.Run(() =>
+                {
+                    byte[] bytes = File.ReadAllBytes(path);
+
+                    // Preview: decode at capped resolution so large sheets don't OOM.
+                    var bi = new BitmapImage();
+                    bi.BeginInit();
+                    bi.StreamSource     = new MemoryStream(bytes);
+                    bi.DecodePixelWidth = 1024;
+                    bi.CacheOption      = BitmapCacheOption.OnLoad;
+                    bi.EndInit();
+                    bi.Freeze();
+
+                    // Full-res Bitmap for slicing.
+                    // IMPORTANT: System.Drawing.Bitmap holds a reference to its source stream
+                    // for its entire lifetime, so the MemoryStream must not be disposed until
+                    // after Clone() completes — Clone() reads the stream data again internally.
+                    var ms   = new MemoryStream(bytes);
+                    var raw  = new Bitmap(ms);
+                    var full = raw.Clone(new DrawingRect(0, 0, raw.Width, raw.Height),
+                                        System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                    raw.Dispose();
+                    ms.Dispose();
+
+                    return (bi, full);
+                });
+
+                _sourceBitmap            = fullBmp;
+                SourcePreview.Source     = preview;
+                SourcePreview.Visibility = Visibility.Visible;
+                DropHint.Text            = "Drop a sprite sheet here, or click Open File";
+                DropHint.Visibility      = Visibility.Collapsed;
+
+                // Reset zoom to 1:1 for each new image.
+                _previewZoom       = 1.0;
+                PreviewScale.ScaleX = 1.0;
+                PreviewScale.ScaleY = 1.0;
+                ZoomBadge.Visibility = Visibility.Collapsed;
+
+                // Defer until the layout pass has measured the container so ActualWidth/Height are valid.
+                Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render,
+                    new Action(UpdateGridOverlay));
+            }
+            catch (Exception ex)
+            {
+                DropHint.Text       = "Drop a sprite sheet here, or click Open File";
+                DropHint.Visibility = Visibility.Visible;
+                SlicerStatusBar.MessageQueue?.Enqueue(
+                    $"Failed to load image: {ex.Message}", null, null, null, false, true, TimeSpan.FromSeconds(4));
+            }
+        }
+
+        private void DropZone_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+                DropZone.BorderBrush = new SolidColorBrush(Colors.MediumPurple);
+        }
+
+        private void DropZone_DragLeave(object sender, DragEventArgs e) => ResetDropZoneBorder();
+
+        private void DropZone_Drop(object sender, DragEventArgs e)
+        {
+            ResetDropZoneBorder();
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (files?.Length > 0)
+                    LoadSourceImage(files[0]);
+            }
+        }
+
+        private void ResetDropZoneBorder() =>
+            DropZone.BorderBrush = new SolidColorBrush(WpfColor.FromRgb(0x67, 0x3A, 0xB7));
+
+        //  grid overlay 
+
+        private void DropZone_SizeChanged(object sender, SizeChangedEventArgs e)
+        {
+            // Keep PreviewContainer the same size as the DropZone viewport at zoom=1
+            // so that Image Stretch=Uniform has finite bounds to work against.
+            double bH = DropZone.BorderThickness.Left + DropZone.BorderThickness.Right;
+            double bV = DropZone.BorderThickness.Top  + DropZone.BorderThickness.Bottom;
+            double w = DropZone.ActualWidth  - bH;
+            double h = DropZone.ActualHeight - bV;
+            if (w > 0) PreviewContainer.Width  = w;
+            if (h > 0) PreviewContainer.Height = h;
+            UpdateGridOverlay();
+        }
+
+        private void SpriteSizeCombo_SelectionChanged(object sender, SelectionChangedEventArgs e) => UpdateGridOverlay();
+
+        private void Offset_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e) => UpdateGridOverlay();
+
+        private void HideGridLinesCheck_Changed(object sender, RoutedEventArgs e) => UpdateGridOverlay();
+
+        private void PreviewScrollViewer_PreviewMouseWheel(object sender, MouseWheelEventArgs e)
+        {
+            if ((Keyboard.Modifiers & ModifierKeys.Control) == ModifierKeys.Control)
+            {
+                // Ctrl + wheel → zoom.
+                double factor = e.Delta > 0 ? 1.2 : 1.0 / 1.2;
+                _previewZoom = Math.Clamp(_previewZoom * factor, 0.25, 12.0);
+                ApplyPreviewZoom();
+                e.Handled = true;
+            }
+            // No Ctrl → let the ScrollViewer handle normal vertical scroll.
+        }
+
+        private void PreviewScrollViewer_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (_sourceBitmap == null) return;
+            _isDraggingPreview  = true;
+            _dragStartPos       = e.GetPosition(PreviewScrollViewer);
+            _dragStartScrollH   = PreviewScrollViewer.HorizontalOffset;
+            _dragStartScrollV   = PreviewScrollViewer.VerticalOffset;
+            PreviewScrollViewer.CaptureMouse();
+            PreviewScrollViewer.Cursor = Cursors.SizeAll;
+            e.Handled = true;
+        }
+
+        private void PreviewScrollViewer_PreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if (!_isDraggingPreview) return;
+            var pos = e.GetPosition(PreviewScrollViewer);
+            PreviewScrollViewer.ScrollToHorizontalOffset(_dragStartScrollH - (pos.X - _dragStartPos.X));
+            PreviewScrollViewer.ScrollToVerticalOffset  (_dragStartScrollV - (pos.Y - _dragStartPos.Y));
+            e.Handled = true;
+        }
+
+        private void PreviewScrollViewer_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+        {
+            if (!_isDraggingPreview) return;
+            _isDraggingPreview = false;
+            PreviewScrollViewer.ReleaseMouseCapture();
+            PreviewScrollViewer.Cursor = null;
+        }
+
+        private void ApplyPreviewZoom()
+        {
+            PreviewScale.ScaleX  = _previewZoom;
+            PreviewScale.ScaleY  = _previewZoom;
+            bool show            = Math.Abs(_previewZoom - 1.0) > 0.01;
+            ZoomBadge.Visibility = show ? Visibility.Visible : Visibility.Collapsed;
+            ZoomLabel.Text       = $"{_previewZoom * 100:F0}%";
+            // Recompute grid so StrokeThickness is compensated for the new zoom level.
+            UpdateGridOverlay();
+        }
+
+        private void UpdateGridOverlay()
+        {
+            GridOverlay.Children.Clear();
+
+            if (_sourceBitmap == null || SpriteSizeCombo.SelectedIndex < 0)
+            {
+                GridOverlay.Visibility = Visibility.Collapsed;
+                return;
+            }
+
+            var size = DatEditor.SpriteSizes[SpriteSizeCombo.SelectedIndex];
+            int sprW  = size.Width;
+            int sprH  = size.Height;
+            int xOff  = XOffset.Value ?? 0;
+            int yOff  = YOffset.Value ?? 0;
+
+            // Compute the rendered image rectangle inside the drop zone (Stretch=Uniform, centred).
+            double borderH = DropZone.BorderThickness.Left + DropZone.BorderThickness.Right;
+            double borderV = DropZone.BorderThickness.Top  + DropZone.BorderThickness.Bottom;
+            double availW  = DropZone.ActualWidth  - borderH;
+            double availH  = DropZone.ActualHeight - borderV;
+            if (availW <= 0 || availH <= 0) return;
+
+            double scale  = Math.Min(availW / _sourceBitmap.Width, availH / _sourceBitmap.Height);
+            double imgW   = _sourceBitmap.Width  * scale;
+            double imgH   = _sourceBitmap.Height * scale;
+            double ox     = (availW - imgW) / 2.0;   // left edge of image in canvas coords
+            double oy     = (availH - imgH) / 2.0;   // top edge
+
+            // Outer image boundary
+            var outerRect = new WpfRect
+            {
+                Width           = imgW,
+                Height          = imgH,
+                Stroke          = new SolidColorBrush(WpfColor.FromArgb(220, 255, 200, 0)),
+                StrokeThickness = 1.0,
+                Fill            = WpfBrushes.Transparent
+            };
+            Canvas.SetLeft(outerRect, ox);
+            Canvas.SetTop(outerRect,  oy);
+            GridOverlay.Children.Add(outerRect);
+
+            var lineBrush     = new SolidColorBrush(WpfColor.FromArgb(190, 255, 80, 0));
+            var dashArray     = new DoubleCollection { 4, 3 };
+            // Compensate thickness so lines stay ~1 px on screen regardless of zoom.
+            double lineThickness = Math.Max(0.1, 0.8 / _previewZoom);
+
+            int colCount  = (int)Math.Ceiling((double)(_sourceBitmap.Width  - xOff) / sprW);
+            int rowCount  = (int)Math.Ceiling((double)(_sourceBitmap.Height - yOff) / sprH);
+            bool hideLines = HideGridLinesCheck.IsChecked == true;
+
+            if (!hideLines)
+            {
+                // Vertical slice lines
+                for (int x = xOff + sprW; x < _sourceBitmap.Width; x += sprW)
+                {
+                    double px = ox + x * scale;
+                    if (px >= ox + imgW) break;
+                    GridOverlay.Children.Add(new WpfLine
+                    {
+                        X1 = px, Y1 = oy + yOff * scale,
+                        X2 = px, Y2 = oy + imgH,
+                        Stroke          = lineBrush,
+                        StrokeThickness = lineThickness,
+                        StrokeDashArray = dashArray
+                    });
+                }
+
+                // Horizontal slice lines
+                for (int y = yOff + sprH; y < _sourceBitmap.Height; y += sprH)
+                {
+                    double py = oy + y * scale;
+                    if (py >= oy + imgH) break;
+                    GridOverlay.Children.Add(new WpfLine
+                    {
+                        X1 = ox + xOff * scale, Y1 = py,
+                        X2 = ox + imgW,         Y2 = py,
+                        Stroke          = lineBrush,
+                        StrokeThickness = lineThickness,
+                        StrokeDashArray = dashArray
+                    });
+                }
+            }
+            else
+            {
+                // Lines hidden — show a small info label so the user knows why.
+                var note = new System.Windows.Controls.TextBlock
+                {
+                    Text       = $"{colCount * rowCount} sprites — grid lines hidden",
+                    Foreground = WpfBrushes.Yellow,
+                    FontSize   = Math.Max(8, 11 / _previewZoom),
+                    Background = new SolidColorBrush(WpfColor.FromArgb(140, 0, 0, 0)),
+                    Padding    = new Thickness(4, 2, 4, 2)
+                };
+                Canvas.SetLeft(note, ox + 4);
+                Canvas.SetTop(note,  oy + 4);
+                GridOverlay.Children.Add(note);
+            }
+
+            GridOverlay.Visibility = Visibility.Visible;
+        }
+
+        //  slicing 
+
+        private async void Slice_Click(object sender, RoutedEventArgs e)
+        {
+            if (_sourceBitmap == null)
+            {
+                SlicerStatusBar.MessageQueue?.Enqueue(
+                    "Please load a source sprite sheet first.", null, null, null, false, true, TimeSpan.FromSeconds(3));
+                return;
+            }
+
+            int spriteTypeIndex = SpriteSizeCombo.SelectedIndex;
+            var size = DatEditor.SpriteSizes[spriteTypeIndex];
+            _currentSprW = size.Width;
+            _currentSprH = size.Height;
+            int xOffset = XOffset.Value ?? 0;
+            int yOffset = YOffset.Value ?? 0;
+
+            // Disable the button so the user can't trigger a second slice while busy.
+            ((System.Windows.Controls.Button)sender).IsEnabled = false;
+            SlicerStatusBar.MessageQueue?.Enqueue(
+                "Slicing… please wait.", null, null, null, false, true, TimeSpan.FromSeconds(60));
+
+            _slicedSprites.Clear();
+            SlicedSpritesPanel.Children.Clear();
+
+            // Capture everything the background thread will need before leaving the UI thread.
+            Bitmap srcSnapshot    = _sourceBitmap;
+            int    sprW           = _currentSprW;
+            int    sprH           = _currentSprH;
+
+            // Detect whether the source carries a real alpha channel.
+            bool sourceHasAlpha = (srcSnapshot.PixelFormat & System.Drawing.Imaging.PixelFormat.Alpha) != 0
+                                  || srcSnapshot.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppArgb
+                                  || srcSnapshot.PixelFormat == System.Drawing.Imaging.PixelFormat.Format32bppPArgb
+                                  || srcSnapshot.PixelFormat == System.Drawing.Imaging.PixelFormat.Format64bppArgb;
+
+            DrawingColor bgColor = sourceHasAlpha
+                ? DrawingColor.Empty
+                : DetectBackgroundColor(srcSnapshot);
+
+            // Run all per-tile work on a thread-pool thread so the UI stays responsive.
+            List<BitmapSource> results = await Task.Run(() =>
+            {
+                var list = new List<BitmapSource>();
+                int col = 0, row = 0;
+                while (yOffset + row * sprH + sprH <= srcSnapshot.Height)
+                {
+                    int x = xOffset + col * sprW;
+                    int y = yOffset + row * sprH;
+
+                    if (x + sprW > srcSnapshot.Width)
+                    {
+                        col = 0;
+                        row++;
+                        continue;
+                    }
+
+                    var rect = new DrawingRect(x, y, sprW, sprH);
+                    using Bitmap raw       = srcSnapshot.Clone(rect, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+                    using Bitmap processed = PrepareSlicedBitmap(raw, sourceHasAlpha, bgColor);
+
+                    // Skip tiles that are entirely transparent/background (all magenta after processing).
+                    if (!IsBlankSprite(processed))
+                    {
+                        BitmapSource bs = Utils.BitmapToBitmapImage(processed);
+                        bs.Freeze();   // required to hand a BitmapSource across threads
+                        list.Add(bs);
+                    }
+                    col++;
+                }
+                return list;
+            });
+
+            ((System.Windows.Controls.Button)sender).IsEnabled = true;
+
+            if (results.Count == 0)
+            {
+                SlicerStatusBar.MessageQueue?.Enqueue(
+                    "No sprites could be sliced with the current settings.", null, null, null, false, true, TimeSpan.FromSeconds(3));
+                return;
+            }
+
+            _slicedSprites.AddRange(results);
+            RebuildSlicedPanel();
+            SlicerStatusBar.MessageQueue?.Enqueue(
+                $"Sliced {_slicedSprites.Count} sprites. Drag any tile onto a sheet slot to insert from that position.",
+                null, null, null, false, true, TimeSpan.FromSeconds(4));
+        }
+
+        private void ClearSlices_Click(object sender, RoutedEventArgs e)
+        {
+            _slicedSprites.Clear();
+            SlicedSpritesPanel.Children.Clear();
+            UpdateSliceCountLabel();
+        }
+
+        //  transparency helpers 
+
+        /// <summary>
+        /// Converts a cropped tile so that transparent (or detected-background) pixels become
+        /// opaque magenta — the format the SprEditor pipeline expects.
+        /// </summary>
+        private static Bitmap PrepareSlicedBitmap(Bitmap crop, bool sourceHasAlpha, DrawingColor bgColor)
+        {
+            Bitmap result = new Bitmap(crop.Width, crop.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            // Normalise to 96 DPI so WPF displays the tile at the expected DIP size,
+            // regardless of whatever DPI metadata the source image file carries.
+            result.SetResolution(96, 96);
+
+            // Draw on a magenta backing.  Use the pixel-rectangle overload so GDI+ copies
+            // exactly crop.Width x crop.Height pixels without applying any DPI-driven
+            // scaling — otherwise a 144-DPI source image would be drawn at ~67 % of the
+            // expected size, leaving magenta corners (the "mini sprite in top-left" bug).
+            using (Graphics g = Graphics.FromImage(result))
+            {
+                g.Clear(DrawingColor.FromArgb(255, 255, 0, 255));
+                g.DrawImage(crop,
+                    new DrawingRect(0, 0, result.Width, result.Height),
+                    new DrawingRect(0, 0, crop.Width,   crop.Height),
+                    GraphicsUnit.Pixel);
+            }
+
+            if (!sourceHasAlpha)
+            {
+                // Source had no alpha channel: every pixel is fully opaque, so the magenta
+                // backing above is completely hidden.  Replace the detected background colour
+                // with magenta ourselves.
+                ReplaceColorWithMagenta(result, bgColor);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if every pixel in <paramref name="bmp"/> is opaque magenta
+        /// (R=255, G=0, B=255, A=255), meaning the tile contains no real content.
+        /// </summary>
+        private static bool IsBlankSprite(Bitmap bmp)
+        {
+            var rect = new DrawingRect(0, 0, bmp.Width, bmp.Height);
+            var data = bmp.LockBits(rect, System.Drawing.Imaging.ImageLockMode.ReadOnly,
+                                    System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            try
+            {
+                int bytes = Math.Abs(data.Stride) * data.Height;
+                byte[] px  = new byte[bytes];
+                Marshal.Copy(data.Scan0, px, 0, bytes);
+                // Memory layout for Format32bppArgb: B G R A
+                for (int i = 0; i < bytes; i += 4)
+                {
+                    if (px[i] != 255 || px[i + 1] != 0 || px[i + 2] != 255 || px[i + 3] != 255)
+                        return false;
+                }
+                return true;
+            }
+            finally
+            {
+                bmp.UnlockBits(data);
+            }
+        }
+
+        /// <summary>Replaces every pixel that exactly matches <paramref name="target"/> with opaque magenta.</summary>
+        private static void ReplaceColorWithMagenta(Bitmap bmp, DrawingColor target)
+        {
+            var rect = new DrawingRect(0, 0, bmp.Width, bmp.Height);
+            var data = bmp.LockBits(rect, System.Drawing.Imaging.ImageLockMode.ReadWrite,
+                                    System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            int bytes = Math.Abs(data.Stride) * data.Height;
+            byte[] pixels = new byte[bytes];
+            Marshal.Copy(data.Scan0, pixels, 0, bytes);
+
+            byte tR = target.R, tG = target.G, tB = target.B;
+
+            for (int i = 0; i < bytes; i += 4)
+            {
+                // Format32bppArgb in memory layout: B G R A
+                if (pixels[i + 2] == tR && pixels[i + 1] == tG && pixels[i] == tB)
+                {
+                    pixels[i]     = 255; // B
+                    pixels[i + 1] = 0;   // G
+                    pixels[i + 2] = 255; // R
+                    pixels[i + 3] = 255; // A — opaque magenta
+                }
+            }
+
+            Marshal.Copy(pixels, 0, data.Scan0, bytes);
+            bmp.UnlockBits(data);
+        }
+
+        /// <summary>
+        /// Samples the four corners of <paramref name="bmp"/> and returns the most common colour
+        /// (falling back to the top-left pixel) as the background colour to remove.
+        /// </summary>
+        private static DrawingColor DetectBackgroundColor(Bitmap bmp)
+        {
+            var corners = new[]
+            {
+                bmp.GetPixel(0, 0),
+                bmp.GetPixel(bmp.Width - 1, 0),
+                bmp.GetPixel(0, bmp.Height - 1),
+                bmp.GetPixel(bmp.Width - 1, bmp.Height - 1)
+            };
+            return corners
+                .GroupBy(c => c.ToArgb())
+                .OrderByDescending(g => g.Count())
+                .First().First();
+        }
+
+        //  tile panel 
+
+        private void TileZoomSlider_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
+        {
+            _tileZoomFactor = e.NewValue;
+            if (TileZoomLabel != null)
+                TileZoomLabel.Text = $"{_tileZoomFactor:F1}x";
+            if (_slicedSprites.Count > 0)
+                RebuildSlicedPanel();
+        }
+
+        private void RebuildSlicedPanel()
+        {
+            SlicedSpritesPanel.Children.Clear();
+            for (int i = 0; i < _slicedSprites.Count; i++)
+                SlicedSpritesPanel.Children.Add(CreateSlicedTile(_slicedSprites[i], i));
+            UpdateSliceCountLabel();
+        }
+
+        private void UpdateSliceCountLabel()
+        {
+            SliceCountLabel.Text = $"{_slicedSprites.Count} sprite{(_slicedSprites.Count == 1 ? "" : "s")}";
+        }
+
+        private Border CreateSlicedTile(BitmapSource bmpSrc, int index)
+        {
+            int baseSize    = Math.Max(32, Math.Min(96, Math.Max(_currentSprW, _currentSprH)));
+            int displaySize = Math.Max(16, (int)Math.Round(baseSize * _tileZoomFactor));
+
+            Border border = new Border
+            {
+                Width           = displaySize,
+                Height          = displaySize,
+                Margin          = new Thickness(2),
+                BorderBrush     = new SolidColorBrush(Colors.Transparent),
+                BorderThickness = new Thickness(1),
+                Cursor          = Cursors.Hand,
+                Tag             = index
+            };
+
+            Image img = new Image
+            {
+                Source              = bmpSrc,
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                VerticalAlignment   = VerticalAlignment.Stretch,
+                Stretch             = Stretch.Uniform
+            };
+            RenderOptions.SetBitmapScalingMode(img, BitmapScalingMode.NearestNeighbor);
+
+            border.Child = img;
+            border.MouseEnter += (s, _) => ((Border)s).BorderBrush = new SolidColorBrush(Colors.MediumPurple);
+            border.MouseLeave += (s, _) => ((Border)s).BorderBrush = new SolidColorBrush(Colors.Transparent);
+            border.MouseDown  += SlicedTile_MouseDown;
+            return border;
+        }
+
+        private void SlicedTile_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            if (e.LeftButton != MouseButtonState.Pressed) return;
+            if (sender is not Border border) return;
+
+            int startIndex = (int)border.Tag;
+            var remaining  = _slicedSprites.Skip(startIndex).ToList();
+            if (remaining.Count == 0) return;
+
+            var data = new SlicedSpritesDragData
+            {
+                Images      = remaining,
+                SourceWindow = this,
+                StartIndex  = startIndex
+            };
+
+            DragDrop.DoDragDrop(border, data, DragDropEffects.Copy);
+        }
+
+        //  called by SprEditor after a successful drop 
+
+        /// <summary>
+        /// Removes sprites that were successfully placed into a sheet, starting at
+        /// <paramref name="startIndex"/> in the slicer's list, for <paramref name="count"/> items.
+        /// </summary>
+        public void RemovePlacedSprites(int startIndex, int count)
+        {
+            int safeCount = Math.Min(count, _slicedSprites.Count - startIndex);
+            if (safeCount <= 0) return;
+
+            _slicedSprites.RemoveRange(startIndex, safeCount);
+            RebuildSlicedPanel();
+
+            string msg = _slicedSprites.Count == 0
+                ? "All sliced sprites have been placed."
+                : $"{safeCount} sprite(s) placed. {_slicedSprites.Count} remaining.";
+            SlicerStatusBar.MessageQueue?.Enqueue(msg, null, null, null, false, true, TimeSpan.FromSeconds(3));
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            base.OnClosed(e);
+            _sourceBitmap?.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Drag-data object used when moving sliced sprites from <see cref="SpriteSlicerWindow"/>
+    /// onto a managed sheet in <see cref="SprEditor"/>.
+    /// </summary>
+    public class SlicedSpritesDragData
+    {
+        public List<BitmapSource> Images { get; set; }
+        public SpriteSlicerWindow SourceWindow { get; set; }
+        /// <summary>Index in the slicer's internal list from which dragging started.</summary>
+        public int StartIndex { get; set; }
+    }
+}

--- a/Assets Editor/SpriteSlicerWindow.xaml.cs
+++ b/Assets Editor/SpriteSlicerWindow.xaml.cs
@@ -354,8 +354,8 @@ namespace Assets_Editor
             SlicerStatusBar.MessageQueue?.Enqueue(
                 "Slicing… please wait.", null, null, null, false, true, TimeSpan.FromSeconds(60));
 
-            _slicedSprites.Clear();
-            SlicedSpritesPanel.Children.Clear();
+            // Release memory from any previous batch before allocating the new one.
+            ClearSlicedSprites();
 
             // Capture everything the background thread will need before leaving the UI thread.
             Bitmap srcSnapshot    = _sourceBitmap;
@@ -423,9 +423,32 @@ namespace Assets_Editor
 
         private void ClearSlices_Click(object sender, RoutedEventArgs e)
         {
-            _slicedSprites.Clear();
+            ClearSlicedSprites();
+        }
+
+        /// <summary>
+        /// Clears all sliced-sprite data and forces a full GC cycle on a background thread so
+        /// the unmanaged WIC/GDI+ memory backing each <see cref="BitmapSource"/> is reclaimed
+        /// promptly rather than waiting for the next scheduled collection.
+        /// </summary>
+        private void ClearSlicedSprites()
+        {
+            // Drop all UI references first so nothing keeps the BitmapSources alive.
             SlicedSpritesPanel.Children.Clear();
+            _slicedSprites.Clear();
             UpdateSliceCountLabel();
+
+            // Run GC on a pool thread to avoid blocking the UI.
+            // Two passes are needed: the first collects the BitmapSource wrappers and
+            // queues their finalizers; WaitForPendingFinalizers lets the finalizer thread
+            // release the unmanaged COM/WIC objects; the second pass collects anything
+            // that became unreachable only after finalization.
+            Task.Run(() =>
+            {
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true);
+                GC.WaitForPendingFinalizers();
+                GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, blocking: true);
+            });
         }
 
         //  transparency helpers 
@@ -638,7 +661,10 @@ namespace Assets_Editor
         protected override void OnClosed(EventArgs e)
         {
             base.OnClosed(e);
+            // Clear sprites and free their unmanaged backing memory.
+            ClearSlicedSprites();
             _sourceBitmap?.Dispose();
+            _sourceBitmap = null;
         }
     }
 


### PR DESCRIPTION
This pull requests adds a small sprite sheet slicer to the assets editor.


Opening up the sprite sheet editor shows a new icon under the sprite sheet, some scissors which will open up the sprite sheet slicer. 

<img width="686" height="633" alt="image" src="https://github.com/user-attachments/assets/f978f24f-d350-44b0-8bf3-9f871092e9a1" />

This will open up the slicer where you can slice sheets

<img width="886" height="713" alt="image" src="https://github.com/user-attachments/assets/c1bc2529-9770-456f-8825-b392f613f1d5" />


The next two screenshots shows one of the open tibia sprite packs sprite sheets fully slices giving a total of 904 sprites to import. Currently, as I am using it to fully import sprite sheets, the function is that you drag and drop your sprites from the sliced window onto the sprite sheet, seen in the two screenshots.

<img width="1593" height="1015" alt="devenv_H6jqi6DsU7" src="https://github.com/user-attachments/assets/110675cd-0d2c-4dd9-b751-296640c189bd" />

<img width="1618" height="1026" alt="devenv_NdzMqzffhl" src="https://github.com/user-attachments/assets/c4badcab-8b2a-4551-a0c9-6dbd65d0201b" />

Once moved into a sprite sheet, it is removed from the sliced sprites location. This allows you to quickly create a new sprite sheet to save new sprites too.


**Note** This was made with AI as I was a bit lazy and I wanted this feature _now_ since I wanted to work with quite a few sprite sheets very quickly. I'm not a professional in C# but it has been working for my own purposes. 