### PR TITLE
feat: add CLI legacy DAT/SPR export profiles

### DIFF
--- a/Assets Editor/App.xaml
+++ b/Assets Editor/App.xaml
@@ -2,7 +2,6 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:Assets_Editor"
-             StartupUri="MainWindow.xaml"
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes">
     <Application.Resources>
         <ResourceDictionary>

--- a/Assets Editor/App.xaml.cs
+++ b/Assets Editor/App.xaml.cs
@@ -6,16 +6,19 @@
 public partial class App : System.Windows.Application {
     public App() { }
 
-    protected override async void OnStartup(System.Windows.StartupEventArgs e)
+    protected override void OnStartup(System.Windows.StartupEventArgs e)
     {
         if (CliExportCommand.IsCli(e.Args))
         {
             ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown;
-            var exitCode = await CliExportCommand.RunAsync(e.Args);
+            var exitCode = CliExportCommand.RunAsync(e.Args).GetAwaiter().GetResult();
             Shutdown(exitCode);
             return;
         }
 
         base.OnStartup(e);
+        var mainWindow = new MainWindow();
+        MainWindow = mainWindow;
+        mainWindow.Show();
     }
 }

--- a/Assets Editor/App.xaml.cs
+++ b/Assets Editor/App.xaml.cs
@@ -5,4 +5,17 @@
 /// </summary>
 public partial class App : System.Windows.Application {
     public App() { }
+
+    protected override async void OnStartup(System.Windows.StartupEventArgs e)
+    {
+        if (CliExportCommand.IsCli(e.Args))
+        {
+            ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown;
+            var exitCode = await CliExportCommand.RunAsync(e.Args);
+            Shutdown(exitCode);
+            return;
+        }
+
+        base.OnStartup(e);
+    }
 }

--- a/Assets Editor/App.xaml.cs
+++ b/Assets Editor/App.xaml.cs
@@ -11,8 +11,18 @@ public partial class App : System.Windows.Application {
         if (CliExportCommand.IsCli(e.Args))
         {
             ShutdownMode = System.Windows.ShutdownMode.OnExplicitShutdown;
-            var exitCode = CliExportCommand.RunAsync(e.Args).GetAwaiter().GetResult();
-            Shutdown(exitCode);
+            var synchronizationContext = System.Threading.SynchronizationContext.Current;
+            try
+            {
+                System.Threading.SynchronizationContext.SetSynchronizationContext(null);
+                var exitCode = CliExportCommand.RunAsync(e.Args).GetAwaiter().GetResult();
+                Shutdown(exitCode);
+            }
+            finally
+            {
+                System.Threading.SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            }
+
             return;
         }
 

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -128,6 +128,7 @@ namespace Assets_Editor
             foreach (var profile in LegacyAssetExportProfiles.All)
             {
                 Console.WriteLine($"{profile.Id}: {profile.DisplayName}");
+                Console.WriteLine($"  {profile.Description}");
             }
         }
 
@@ -136,6 +137,11 @@ namespace Assets_Editor
             Console.WriteLine("Usage:");
             Console.WriteLine("  Assets Editor.exe --list-profiles");
             Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
+            Console.WriteLine();
+            Console.WriteLine("Profile notes:");
+            Console.WriteLine("  cip860-extended keeps the CipSoft 8.60 dat object layout and writes extended uint32 sprite ids.");
+            Console.WriteLine("  It intentionally does not write modern dat flags such as Clothes/attr 32, Market, DefaultAction, Wrap, or TopEffect.");
+            Console.WriteLine("  Outfit colors still come from the game protocol lookHead/lookBody/lookLegs/lookFeet/lookAddons fields and the classic outfit sprite layout.");
         }
 
         private sealed class InlineProgress<T> : IProgress<T>

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -12,6 +12,7 @@ namespace Assets_Editor
         {
             return args.Length > 0 &&
                 (string.Equals(args[0], "export-legacy", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(args[0], "validate-legacy", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(args[0], "--list-profiles", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(args[0], "--help", StringComparison.OrdinalIgnoreCase) ||
                  string.Equals(args[0], "-h", StringComparison.OrdinalIgnoreCase));
@@ -32,6 +33,31 @@ namespace Assets_Editor
                 if (string.Equals(args[0], "--list-profiles", StringComparison.OrdinalIgnoreCase))
                 {
                     PrintProfiles();
+                    return 0;
+                }
+
+                if (string.Equals(args[0], "validate-legacy", StringComparison.OrdinalIgnoreCase))
+                {
+                    var validateValues = ParseOptions(args);
+                    var validateProfile = LegacyAssetExportProfiles.Get(GetValue(validateValues, "profile"));
+                    var datPath = GetValue(validateValues, "dat");
+                    validateValues.TryGetValue("spr", out var sprPath);
+                    if (!string.IsNullOrWhiteSpace(sprPath))
+                    {
+                        LegacyDatValidator.ValidateFiles(datPath, sprPath, validateProfile);
+                    }
+                    else
+                    {
+                        LegacyDatValidator.ValidateExport(datPath, validateProfile, uint.MaxValue);
+                    }
+
+                    Console.WriteLine($"validated profile={validateProfile.Id}");
+                    Console.WriteLine($"dat={Path.GetFullPath(datPath)}");
+                    if (!string.IsNullOrWhiteSpace(sprPath))
+                    {
+                        Console.WriteLine($"spr={Path.GetFullPath(sprPath)}");
+                    }
+
                     return 0;
                 }
 
@@ -141,6 +167,7 @@ namespace Assets_Editor
             Console.WriteLine("Usage:");
             Console.WriteLine("  Assets Editor.exe --list-profiles");
             Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
+            Console.WriteLine("  Assets Editor.exe validate-legacy --profile client11-15x --dat <Tibia.dat> [--spr <Tibia.spr>]");
             Console.WriteLine();
             Console.WriteLine("Profile notes:");
             Console.WriteLine("  cip860-extended keeps the CipSoft 8.60 dat object layout and writes extended uint32 sprite ids.");

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -83,6 +83,7 @@ namespace Assets_Editor
                     Profile = profile,
                     Overwrite = values.ContainsKey("overwrite"),
                     Backup = !values.ContainsKey("no-backup"),
+                    ExportItemFlagOtml = !values.ContainsKey("no-item-flag-otml"),
                 };
 
                 var exporter = new LegacyAssetExporter();
@@ -95,6 +96,11 @@ namespace Assets_Editor
                 Console.WriteLine($"exported profile={result.Profile.Id}");
                 Console.WriteLine($"dat={result.DatPath}");
                 Console.WriteLine($"spr={result.SprPath}");
+                if (!string.IsNullOrWhiteSpace(result.ItemFlagOtmlPath))
+                {
+                    Console.WriteLine($"itemFlag={result.ItemFlagOtmlPath}");
+                    Console.WriteLine($"itemFlagItems={result.ItemFlagOtmlItems}");
+                }
                 foreach (var backup in result.Backups)
                 {
                     Console.WriteLine($"backup={backup}");
@@ -122,7 +128,7 @@ namespace Assets_Editor
                 }
 
                 var key = arg[2..];
-                if (key is "overwrite" or "no-backup" or "list-profiles")
+                if (key is "overwrite" or "no-backup" or "list-profiles" or "no-item-flag-otml")
                 {
                     values[key] = null;
                     continue;
@@ -166,8 +172,8 @@ namespace Assets_Editor
         {
             Console.WriteLine("Usage:");
             Console.WriteLine("  Assets Editor.exe --list-profiles");
-            Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
-            Console.WriteLine("  Assets Editor.exe export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
+            Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]");
+            Console.WriteLine("  Assets Editor.exe export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]");
             Console.WriteLine("  Assets Editor.exe validate-legacy --profile client11-15x --dat <Tibia.dat> [--spr <Tibia.spr>]");
             Console.WriteLine();
             Console.WriteLine("Profile notes:");

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -167,6 +167,7 @@ namespace Assets_Editor
             Console.WriteLine("Usage:");
             Console.WriteLine("  Assets Editor.exe --list-profiles");
             Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
+            Console.WriteLine("  Assets Editor.exe export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
             Console.WriteLine("  Assets Editor.exe validate-legacy --profile client11-15x --dat <Tibia.dat> [--spr <Tibia.spr>]");
             Console.WriteLine();
             Console.WriteLine("Profile notes:");

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -129,6 +129,10 @@ namespace Assets_Editor
             {
                 Console.WriteLine($"{profile.Id}: {profile.DisplayName}");
                 Console.WriteLine($"  {profile.Description}");
+                if (profile.MaxMarketNameLength > 0)
+                {
+                    Console.WriteLine($"  Market names are capped at {profile.MaxMarketNameLength} characters.");
+                }
             }
         }
 
@@ -142,6 +146,7 @@ namespace Assets_Editor
             Console.WriteLine("  cip860-extended keeps the CipSoft 8.60 dat object layout and writes extended uint32 sprite ids.");
             Console.WriteLine("  It intentionally does not write modern dat flags such as Clothes/attr 32, Market, DefaultAction, Wrap, or TopEffect.");
             Console.WriteLine("  Outfit colors still come from the game protocol lookHead/lookBody/lookLegs/lookFeet/lookAddons fields and the classic outfit sprite layout.");
+            Console.WriteLine("  client11-15x keeps the 10/11 dat layout and caps Market names at 29 characters because that executable fails to open longer Market names.");
         }
 
         private sealed class InlineProgress<T> : IProgress<T>

--- a/Assets Editor/CliExportCommand.cs
+++ b/Assets Editor/CliExportCommand.cs
@@ -1,0 +1,180 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace Assets_Editor
+{
+    public static class CliExportCommand
+    {
+        public static bool IsCli(string[] args)
+        {
+            return args.Length > 0 &&
+                (string.Equals(args[0], "export-legacy", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(args[0], "--list-profiles", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(args[0], "--help", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(args[0], "-h", StringComparison.OrdinalIgnoreCase));
+        }
+
+        public static async Task<int> RunAsync(string[] args)
+        {
+            ConsoleBridge.AttachParentConsole();
+
+            try
+            {
+                if (args.Length == 0 || string.Equals(args[0], "--help", StringComparison.OrdinalIgnoreCase) || string.Equals(args[0], "-h", StringComparison.OrdinalIgnoreCase))
+                {
+                    PrintHelp();
+                    return 0;
+                }
+
+                if (string.Equals(args[0], "--list-profiles", StringComparison.OrdinalIgnoreCase))
+                {
+                    PrintProfiles();
+                    return 0;
+                }
+
+                if (!string.Equals(args[0], "export-legacy", StringComparison.OrdinalIgnoreCase))
+                {
+                    Console.Error.WriteLine($"Unknown command '{args[0]}'.");
+                    PrintHelp();
+                    return 2;
+                }
+
+                var values = ParseOptions(args);
+                if (values.ContainsKey("list-profiles"))
+                {
+                    PrintProfiles();
+                    return 0;
+                }
+
+                var profile = LegacyAssetExportProfiles.Get(GetValue(values, "profile"));
+                var options = new LegacyAssetExportOptions
+                {
+                    InputPath = GetValue(values, "input"),
+                    OutputPath = GetValue(values, "output"),
+                    Profile = profile,
+                    Overwrite = values.ContainsKey("overwrite"),
+                    Backup = !values.ContainsKey("no-backup"),
+                };
+
+                var exporter = new LegacyAssetExporter();
+                var result = await exporter.ExportAsync(
+                    options,
+                    new InlineProgress<string>(message => Console.WriteLine(message)),
+                    new InlineProgress<int>(percent => Console.WriteLine($"sprite-slicing {percent}%")),
+                    new InlineProgress<int>(percent => Console.WriteLine($"spr-writing {percent}%")));
+
+                Console.WriteLine($"exported profile={result.Profile.Id}");
+                Console.WriteLine($"dat={result.DatPath}");
+                Console.WriteLine($"spr={result.SprPath}");
+                foreach (var backup in result.Backups)
+                {
+                    Console.WriteLine($"backup={backup}");
+                }
+
+                return 0;
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(exception.Message);
+                Console.Error.WriteLine(exception);
+                return 1;
+            }
+        }
+
+        private static Dictionary<string, string> ParseOptions(string[] args)
+        {
+            var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            for (var index = 1; index < args.Length; index++)
+            {
+                var arg = args[index];
+                if (!arg.StartsWith("--", StringComparison.Ordinal))
+                {
+                    throw new ArgumentException($"Unexpected positional argument '{arg}'.");
+                }
+
+                var key = arg[2..];
+                if (key is "overwrite" or "no-backup" or "list-profiles")
+                {
+                    values[key] = null;
+                    continue;
+                }
+
+                if (index + 1 >= args.Length)
+                {
+                    throw new ArgumentException($"Missing value for option '{arg}'.");
+                }
+
+                values[key] = args[++index];
+            }
+
+            return values;
+        }
+
+        private static string GetValue(Dictionary<string, string> values, string key)
+        {
+            if (!values.TryGetValue(key, out var value) || string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException($"Missing required option '--{key}'.");
+            }
+
+            return value;
+        }
+
+        private static void PrintProfiles()
+        {
+            foreach (var profile in LegacyAssetExportProfiles.All)
+            {
+                Console.WriteLine($"{profile.Id}: {profile.DisplayName}");
+            }
+        }
+
+        private static void PrintHelp()
+        {
+            Console.WriteLine("Usage:");
+            Console.WriteLine("  Assets Editor.exe --list-profiles");
+            Console.WriteLine("  Assets Editor.exe export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]");
+        }
+
+        private sealed class InlineProgress<T> : IProgress<T>
+        {
+            private readonly Action<T> report;
+
+            public InlineProgress(Action<T> report)
+            {
+                this.report = report;
+            }
+
+            public void Report(T value)
+            {
+                report(value);
+            }
+        }
+
+        private static class ConsoleBridge
+        {
+            private const int AttachParentProcess = -1;
+
+            [DllImport("kernel32.dll")]
+            private static extern bool AttachConsole(int dwProcessId);
+
+            [DllImport("kernel32.dll")]
+            private static extern IntPtr GetConsoleWindow();
+
+            public static void AttachParentConsole()
+            {
+                if (GetConsoleWindow() == IntPtr.Zero)
+                {
+                    AttachConsole(AttachParentProcess);
+                }
+
+                var stdout = Console.OpenStandardOutput();
+                var stderr = Console.OpenStandardError();
+                Console.SetOut(new StreamWriter(stdout) { AutoFlush = true });
+                Console.SetError(new StreamWriter(stderr) { AutoFlush = true });
+            }
+        }
+    }
+}

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -26,9 +26,11 @@
         </Grid.IsHitTestVisible>
         <materialDesign:DialogHost Grid.Row="1" x:Name="ComppileDialogHost" OverlayBackground="Gray">
             <materialDesign:DialogHost.DialogContent>
-                <GroupBox x:Name="CompileBox" Header="Export To Legacy" Width="460">
+                <GroupBox x:Name="CompileBox" Header="Export To Legacy" Width="620">
                     <Grid >
                         <Grid.RowDefinitions>
+                            <RowDefinition Height="40"/>
+                            <RowDefinition Height="40"/>
                             <RowDefinition Height="40"/>
                             <RowDefinition Height="70"/>
                             <RowDefinition Height="40"/>
@@ -43,8 +45,29 @@
                             <Label Grid.Column="0" Content="Profile" VerticalAlignment="Center"/>
                             <ComboBox Grid.Column="1" x:Name="C_LegacyProfile" Margin="5" SelectionChanged="LegacyProfile_SelectionChanged"/>
                         </Grid>
-                        <TextBlock Grid.Row="1" x:Name="C_LegacyProfileDescription" Margin="8,0" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                        <Grid Grid.Row="1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Content="Output" VerticalAlignment="Center"/>
+                            <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
+                                <RadioButton x:Name="C_LegacyDefaultOutput" Content="Program folder" IsChecked="True" Checked="LegacyOutputMode_Changed" Margin="5,0,20,0"/>
+                                <RadioButton x:Name="C_LegacyCustomOutput" Content="Choose folder" Checked="LegacyOutputMode_Changed" Margin="5,0"/>
+                            </StackPanel>
+                        </Grid>
                         <Grid Grid.Row="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="85"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Content="Path" VerticalAlignment="Center"/>
+                            <TextBox Grid.Column="1" x:Name="C_LegacyOutputPath" Margin="5" VerticalContentAlignment="Center"/>
+                            <Button Grid.Column="2" x:Name="C_LegacyBrowseOutputPath" Content="Browse" Click="LegacyOutputPathPicker_Click" Margin="5" Width="75"/>
+                        </Grid>
+                        <TextBlock Grid.Row="3" x:Name="C_LegacyProfileDescription" Margin="8,0" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                        <Grid Grid.Row="4">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="210"/>
@@ -52,7 +75,7 @@
                             <Label Grid.Column="0" Content="Converting Objects"/>
                             <ProgressBar Grid.Column="1" x:Name="LoadProgress1" Minimum="0" Maximum="100" Value="0" Width="200" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,5,10" Height="8" />
                         </Grid>
-                        <Grid Grid.Row="3">
+                        <Grid Grid.Row="5">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="210"/>
@@ -60,7 +83,7 @@
                             <Label Grid.Column="0" Content="Converting Sprites"/>
                             <ProgressBar Grid.Column="1" x:Name="LoadProgress2" Minimum="0" Maximum="100" Value="0" Width="200" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,5,10" Height="8" />
                         </Grid>
-                        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center">
+                        <StackPanel Grid.Row="6" Orientation="Horizontal" HorizontalAlignment="Center">
                             <Button Click="CompileLegacy" Content="Export" Width="100" Margin="0,0,20,0"/>
                             <Button Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}" Content="Cancel" Width="100"/>
                         </StackPanel>

--- a/Assets Editor/DatEditor.xaml
+++ b/Assets Editor/DatEditor.xaml
@@ -26,16 +26,25 @@
         </Grid.IsHitTestVisible>
         <materialDesign:DialogHost Grid.Row="1" x:Name="ComppileDialogHost" OverlayBackground="Gray">
             <materialDesign:DialogHost.DialogContent>
-                <GroupBox x:Name="CompileBox" Header="Export To Legacy" Width="350">
+                <GroupBox x:Name="CompileBox" Header="Export To Legacy" Width="460">
                     <Grid >
                         <Grid.RowDefinitions>
                             <RowDefinition Height="40"/>
+                            <RowDefinition Height="70"/>
                             <RowDefinition Height="40"/>
                             <RowDefinition Height="40"/>
                             <RowDefinition Height="40"/>
                         </Grid.RowDefinitions>
-                        <CheckBox Grid.Row="0" x:Name="C_Transparent" Content="Transparent" Margin="5,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                        <Grid Grid.Row="1">
+                        <Grid Grid.Row="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="100"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Content="Profile" VerticalAlignment="Center"/>
+                            <ComboBox Grid.Column="1" x:Name="C_LegacyProfile" Margin="5" SelectionChanged="LegacyProfile_SelectionChanged"/>
+                        </Grid>
+                        <TextBlock Grid.Row="1" x:Name="C_LegacyProfileDescription" Margin="8,0" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                        <Grid Grid.Row="2">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="210"/>
@@ -43,7 +52,7 @@
                             <Label Grid.Column="0" Content="Converting Objects"/>
                             <ProgressBar Grid.Column="1" x:Name="LoadProgress1" Minimum="0" Maximum="100" Value="0" Width="200" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,5,10" Height="8" />
                         </Grid>
-                        <Grid Grid.Row="2">
+                        <Grid Grid.Row="3">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="*"/>
                                 <ColumnDefinition Width="210"/>
@@ -51,7 +60,7 @@
                             <Label Grid.Column="0" Content="Converting Sprites"/>
                             <ProgressBar Grid.Column="1" x:Name="LoadProgress2" Minimum="0" Maximum="100" Value="0" Width="200" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5,0,5,10" Height="8" />
                         </Grid>
-                        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Center">
+                        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Center">
                             <Button Click="CompileLegacy" Content="Export" Width="100" Margin="0,0,20,0"/>
                             <Button Command="{x:Static materialDesign:DialogHost.CloseDialogCommand}" Content="Cancel" Width="100"/>
                         </StackPanel>

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -2394,6 +2394,11 @@ namespace Assets_Editor
                     MainWindow.Log($"Created backup '{backup}'");
                 }
 
+                if (!string.IsNullOrWhiteSpace(result.ItemFlagOtmlPath))
+                {
+                    MainWindow.Log($"Created item flag sidecar '{result.ItemFlagOtmlPath}' ({result.ItemFlagOtmlItems} item(s))");
+                }
+
                 ComppileDialogHost.IsOpen = false;
             }
             catch (Exception exception)

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -211,6 +211,11 @@ namespace Assets_Editor
         public DatEditor()
         {
             InitializeComponent();
+            C_LegacyProfile.ItemsSource = LegacyAssetExportProfiles.All;
+            C_LegacyProfile.DisplayMemberPath = nameof(LegacyAssetExportProfile.DisplayName);
+            C_LegacyProfile.SelectedValuePath = nameof(LegacyAssetExportProfile.Id);
+            C_LegacyProfile.SelectedItem = LegacyAssetExportProfiles.Get("cip860-extended");
+            UpdateLegacyProfileDescription();
 
             // set current theme
             DarkModeToggle.IsChecked = MainWindow.IsDarkModeSet();
@@ -2073,6 +2078,30 @@ namespace Assets_Editor
             CompileBox.IsEnabled = true;
             LoadProgress1.Value = 0;
             LoadProgress2.Value = 0;
+            UpdateLegacyProfileDescription();
+        }
+
+        private void LegacyProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateLegacyProfileDescription();
+        }
+
+        private LegacyAssetExportProfile GetSelectedLegacyProfile()
+        {
+            return C_LegacyProfile.SelectedItem as LegacyAssetExportProfile ?? LegacyAssetExportProfiles.Get("cip860-extended");
+        }
+
+        private void UpdateLegacyProfileDescription()
+        {
+            if (C_LegacyProfileDescription == null)
+            {
+                return;
+            }
+
+            var profile = GetSelectedLegacyProfile();
+            C_LegacyProfileDescription.Text = profile.MaxMarketNameLength > 0
+                ? $"{profile.Description} Market names are capped at {profile.MaxMarketNameLength} characters."
+                : profile.Description;
         }
 
         private async void CompileLegacy(object sender, RoutedEventArgs e)
@@ -2257,184 +2286,55 @@ namespace Assets_Editor
         private async Task ExportLegacy(IProgress<int> progress)
         {
             CompileBox.IsEnabled = false;
-            SpriteStorage tmpSprStorage = new();
-            Appearances tmpAppearances = new();
-            ConcurrentDictionary<int, List<MemoryStream>> SlicedSprList = [];
-            ConcurrentDictionary<string, uint> SpriteOffsetList = [];
-            bool transparent = C_Transparent.IsChecked ?? false;
+            LoadProgress1.Value = 0;
+            LoadProgress2.Value = 0;
 
-            string datfile = MainWindow._assetsPath + "Tibia.dat";
-            VersionInfo? legacyEncoder = ObdDecoder.GetDatStructure();
-            if (legacyEncoder == null) {
-                ErrorManager.ShowError("obd structure not defined in appearances.xml!");
-                return;
-            }
-
-            // write DAT
-            await Task.Run(() =>
+            try
             {
-                int percentageComplete = 0;
-                int currentPercentage = 0;
-                int FullProgress = MainWindow.catalog.Count;
-                var options = new ParallelOptions()
+                var profile = GetSelectedLegacyProfile();
+                var exporter = new LegacyAssetExporter();
+                var sprProgress = new Progress<int>(percent =>
                 {
-                    MaxDegreeOfParallelism = Environment.ProcessorCount
-                };
-                int progressCount = 0;
-                Parallel.ForEach(MainWindow.catalog, options, (sheet, state) =>
-                {
-                    if (sheet.Type == "sprite")
-                    {
-                        string lzma = String.Format("{0}{1}", MainWindow._assetsPath, sheet.File);
-                        if (File.Exists(lzma) == false)
-                        {
-                            Debug.WriteLine("File Doesn't exists: " + sheet.File);
-                            return;
-                        }
-                        for (int i = sheet.FirstSpriteid; i <= sheet.LastSpriteid; i++)
-                        {
-                            System.Drawing.Bitmap bitmap = new(MainWindow.getSpriteStream(i));
-                            List<System.Drawing.Bitmap> slices = SplitImage(bitmap);
-                            SlicedSprList[i] = [];
-                            for (int j = 0; j < slices.Count; j++)
-                            {
-                                if (IsImageFullyTransparent(slices[j]) == false)
-                                {
-                                    MemoryStream ms = new();
-                                    slices[j].Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-                                    ms.Position = 0;
-                                    SlicedSprList[i].Add(ms);
-                                }
-                                else
-                                {
-                                    SlicedSprList[i].Add(null);
-                                }
-
-                            }
-                        }
-                        progressCount++;
-                        percentageComplete = (int)(progressCount * 100 / FullProgress);
-                        if (percentageComplete > currentPercentage)
-                        {
-                            progress?.Report(percentageComplete);
-                            currentPercentage = percentageComplete;
-                        }
-                    }
+                    LoadProgress2.Value = percent;
                 });
 
-                uint count = 1;
-                foreach (int key in SlicedSprList.Keys)
-                {
-                    List<MemoryStream> memoryStreams = SlicedSprList[key];
-                    int streamCounter = 0;
-                    foreach (MemoryStream stream in memoryStreams)
+                var result = await exporter.ExportAsync(
+                    new LegacyAssetExportOptions
                     {
-                        string sprName = key.ToString() + "_" + streamCounter.ToString();
-                        if (stream == null)
-                        {
-                            SpriteOffsetList[sprName] = 0;
-                        }
-                        else
-                        {
-                            tmpSprStorage.SprLists[(int)count] = stream;
-                            SpriteOffsetList[sprName] = count;
-                            count++;
-                        }
-                        streamCounter++;
-                    }
+                        InputPath = MainWindow._assetsPath,
+                        OutputPath = MainWindow._assetsPath,
+                        Profile = profile,
+                        Overwrite = true,
+                        Backup = true,
+                    },
+                    new Progress<string>(message => MainWindow.Log(message)),
+                    progress,
+                    sprProgress);
+
+                await Task.Run(() =>
+                {
+                    string otfile = Path.Combine(MainWindow._assetsPath, "Tibia.otfi");
+                    Utils.WritePresetToOtfi(otfile, in AssetsPreset, result.DatPath, result.SprPath, result.Profile.Transparency);
+                });
+
+                foreach (var backup in result.Backups)
+                {
+                    MainWindow.Log($"Created backup '{backup}'");
                 }
 
-
-                tmpAppearances = MainWindow.appearances.Clone();
-
-                uint ObjectCount = tmpAppearances.Object.Max(a => a.Id);
-                uint OutfitCount = tmpAppearances.Outfit.Max(a => a.Id);
-                uint EffectCount = tmpAppearances.Effect.Max(a => a.Id);
-                uint MissileCount = tmpAppearances.Missile.Max(a => a.Id);
-                for (uint i = 100; i <= ObjectCount; i++)
-                {
-                    Appearance appearance = tmpAppearances.Object.FirstOrDefault(a => a.Id == i);
-                    if (appearance == null)
-                    {
-                        Appearance newObject = CreateBlankObject(i, APPEARANCE_TYPE.AppearanceObject);
-                        tmpAppearances.Object.Add(newObject);
-                    }
-                    else
-                    {
-                        appearance.AppearanceType = APPEARANCE_TYPE.AppearanceObject;
-                        if (appearance.Flags.Hook != null)
-                        {
-                            if (appearance.Flags.Hook.Direction == HOOK_TYPE.South)
-                                appearance.Flags.HookSouth = true;
-
-                            if (appearance.Flags.Hook.Direction == HOOK_TYPE.East)
-                                appearance.Flags.HookEast = true;
-                        }
-                        UpdateAppearanceObject(appearance, SpriteOffsetList);
-                    }
-                }
-                for (uint i = 1; i <= OutfitCount; i++)
-                {
-                    Appearance appearance = tmpAppearances.Outfit.FirstOrDefault(a => a.Id == i);
-                    if (appearance == null)
-                    {
-                        Appearance newObject = CreateBlankObject(i, APPEARANCE_TYPE.AppearanceOutfit);
-                        tmpAppearances.Outfit.Add(newObject);
-                    }
-                    else
-                    {
-                        appearance.AppearanceType = APPEARANCE_TYPE.AppearanceOutfit;
-                        UpdateAppearanceObject(appearance, SpriteOffsetList);
-                    }
-                }
-                for (uint i = 1; i <= EffectCount; i++)
-                {
-                    Appearance appearance = tmpAppearances.Effect.FirstOrDefault(a => a.Id == i);
-                    if (appearance == null)
-                    {
-                        Appearance newObject = CreateBlankObject(i, APPEARANCE_TYPE.AppearanceEffect);
-                        tmpAppearances.Effect.Add(newObject);
-                    }
-                    else
-                    {
-                        appearance.AppearanceType = APPEARANCE_TYPE.AppearanceEffect;
-                        UpdateAppearanceObject(appearance, SpriteOffsetList);
-                    }
-                }
-                for (uint i = 1; i <= MissileCount; i++)
-                {
-                    Appearance appearance = tmpAppearances.Missile.FirstOrDefault(a => a.Id == i);
-                    if (appearance == null)
-                    {
-                        Appearance newObject = CreateBlankObject(i, APPEARANCE_TYPE.AppearanceMissile);
-                        tmpAppearances.Missile.Add(newObject);
-                    }
-                    else
-                    {
-                        appearance.AppearanceType = APPEARANCE_TYPE.AppearanceMissile;
-                        UpdateAppearanceObject(appearance, SpriteOffsetList);
-                    }
-                }
-
-                LegacyAppearance.WriteLegacyDat(datfile, 0x42A3, tmpAppearances, legacyEncoder.Structure);
-            });
-
-            // write SPR
-            var progress1 = new Progress<int>(percent =>
+                ComppileDialogHost.IsOpen = false;
+            }
+            catch (Exception exception)
             {
-                LoadProgress2.Value = percent;
-            });
-            string sprfile = MainWindow._assetsPath + "Tibia.spr";
-            await Sprite.CompileSpritesAsync(sprfile, tmpSprStorage, transparent, 0x53159CA9, progress1);
-
-            // write OTFI
-            await Task.Run(() => {
-                string otfile = MainWindow._assetsPath + "Tibia.otfi";
-                Utils.WritePresetToOtfi(otfile, in AssetsPreset, datfile, sprfile, transparent);
-            });
-
-            ComppileDialogHost.IsOpen = false;
+                ErrorManager.ShowError(exception.Message);
+                MainWindow.Log(exception.ToString(), "Error");
+            }
+            finally
+            {
+                CompileBox.IsEnabled = true;
+            }
         }
+
         private void NumberValidationTextBox(object sender, TextCompositionEventArgs e)
         {
             Regex regex = new Regex("[^0-9]+");

--- a/Assets Editor/DatEditor.xaml.cs
+++ b/Assets Editor/DatEditor.xaml.cs
@@ -216,6 +216,7 @@ namespace Assets_Editor
             C_LegacyProfile.SelectedValuePath = nameof(LegacyAssetExportProfile.Id);
             C_LegacyProfile.SelectedItem = LegacyAssetExportProfiles.Get("cip860-extended");
             UpdateLegacyProfileDescription();
+            UpdateLegacyOutputPathState();
 
             // set current theme
             DarkModeToggle.IsChecked = MainWindow.IsDarkModeSet();
@@ -2079,16 +2080,85 @@ namespace Assets_Editor
             LoadProgress1.Value = 0;
             LoadProgress2.Value = 0;
             UpdateLegacyProfileDescription();
+            UpdateLegacyOutputPathState();
         }
 
         private void LegacyProfile_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
             UpdateLegacyProfileDescription();
+            UpdateLegacyOutputPathState();
+        }
+
+        private void LegacyOutputMode_Changed(object sender, RoutedEventArgs e)
+        {
+            UpdateLegacyOutputPathState();
+        }
+
+        private void LegacyOutputPathPicker_Click(object sender, RoutedEventArgs e)
+        {
+            using FolderBrowserDialog dialog = new()
+            {
+                ClientGuid = Globals.GUID_DatEditor5
+            };
+            dialog.Description = "Select the directory to export Tibia.dat and Tibia.spr.";
+            dialog.ShowNewFolderButton = true;
+
+            string currentOutputPath = (C_LegacyOutputPath.Text ?? string.Empty).Trim();
+            if (!string.IsNullOrWhiteSpace(currentOutputPath) && Directory.Exists(currentOutputPath))
+            {
+                dialog.SelectedPath = currentOutputPath;
+            }
+            else if (Directory.Exists(AppContext.BaseDirectory))
+            {
+                dialog.SelectedPath = AppContext.BaseDirectory;
+            }
+
+            if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+            {
+                C_LegacyCustomOutput.IsChecked = true;
+                C_LegacyOutputPath.Text = dialog.SelectedPath;
+            }
         }
 
         private LegacyAssetExportProfile GetSelectedLegacyProfile()
         {
             return C_LegacyProfile.SelectedItem as LegacyAssetExportProfile ?? LegacyAssetExportProfiles.Get("cip860-extended");
+        }
+
+        private string GetLegacyOutputPath()
+        {
+            string outputPath = C_LegacyCustomOutput.IsChecked == true
+                ? (C_LegacyOutputPath.Text ?? string.Empty).Trim()
+                : GetDefaultLegacyOutputPath();
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new InvalidOperationException("Select the directory to export Tibia.dat and Tibia.spr.");
+            }
+
+            return Path.GetFullPath(outputPath);
+        }
+
+        private string GetDefaultLegacyOutputPath()
+        {
+            var profile = GetSelectedLegacyProfile();
+            return Path.Combine(AppContext.BaseDirectory, "legacy-exports", profile.Id);
+        }
+
+        private void UpdateLegacyOutputPathState()
+        {
+            if (C_LegacyOutputPath == null || C_LegacyBrowseOutputPath == null || C_LegacyCustomOutput == null)
+            {
+                return;
+            }
+
+            bool customOutput = C_LegacyCustomOutput.IsChecked == true;
+            C_LegacyOutputPath.IsReadOnly = !customOutput;
+            C_LegacyBrowseOutputPath.IsEnabled = customOutput;
+
+            if (!customOutput)
+            {
+                C_LegacyOutputPath.Text = GetDefaultLegacyOutputPath();
+            }
         }
 
         private void UpdateLegacyProfileDescription()
@@ -2292,17 +2362,19 @@ namespace Assets_Editor
             try
             {
                 var profile = GetSelectedLegacyProfile();
+                var outputPath = GetLegacyOutputPath();
                 var exporter = new LegacyAssetExporter();
                 var sprProgress = new Progress<int>(percent =>
                 {
                     LoadProgress2.Value = percent;
                 });
+                MainWindow.Log($"Exporting legacy assets to '{outputPath}'");
 
                 var result = await exporter.ExportAsync(
                     new LegacyAssetExportOptions
                     {
                         InputPath = MainWindow._assetsPath,
-                        OutputPath = MainWindow._assetsPath,
+                        OutputPath = outputPath,
                         Profile = profile,
                         Overwrite = true,
                         Backup = true,
@@ -2313,7 +2385,7 @@ namespace Assets_Editor
 
                 await Task.Run(() =>
                 {
-                    string otfile = Path.Combine(MainWindow._assetsPath, "Tibia.otfi");
+                    string otfile = Path.Combine(outputPath, "Tibia.otfi");
                     Utils.WritePresetToOtfi(otfile, in AssetsPreset, result.DatPath, result.SprPath, result.Profile.Transparency);
                 });
 

--- a/Assets Editor/Globals.cs
+++ b/Assets Editor/Globals.cs
@@ -14,6 +14,7 @@ public class Globals {
     public static readonly Guid GUID_DatEditor2 = new("4FC8F7A5-4840-4840-A68B-26DFD955D224"); // export sprite as bitmap
     public static readonly Guid GUID_DatEditor3 = new("1A5860A3-5722-4FFC-B6F2-FCE4E9FE255F"); // import aec/obd
     public static readonly Guid GUID_DatEditor4 = new("5788DE66-9141-4995-9550-118FCFE88609"); // export as aec
+    public static readonly Guid GUID_DatEditor5 = new("F5835C7B-53CB-4D56-9C1F-55F2C12DF981"); // legacy export client path
 
     public static readonly Guid GUID_LegacyDatEditor1 = new("AB8D0A9E-F28F-4C63-8F76-EE41552BE4BB"); // export sprite as bitmap
     public static readonly Guid GUID_LegacyDatEditor2 = new("9BA45B21-456E-469C-9F15-1045455F348F"); // import sprite from bitmap

--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -237,6 +237,7 @@ namespace Assets_Editor
             {
                 Id = "legacy1098-custom",
                 DisplayName = "Legacy 10.98 compatible",
+                Description = "Legacy 10.98 compatible export with a custom dat signature.",
                 DatLayout = LegacyDatLayout.Tibia1098,
                 DatSignature = signature,
                 SprSignature = 0,
@@ -295,7 +296,7 @@ namespace Assets_Editor
                 return;
             }
 
-            WriteAppearance1098(w, appearance);
+            WriteAppearance1098(w, appearance, profile);
         }
 
         public static void WriteAppearance860(BinaryWriter w, Appearance item, LegacyAssetExportProfile profile)
@@ -641,6 +642,11 @@ namespace Assets_Editor
 
         public static void WriteAppearance1098(BinaryWriter w, Appearance item)
         {
+            WriteAppearance1098(w, item, null);
+        }
+
+        public static void WriteAppearance1098(BinaryWriter w, Appearance item, LegacyAssetExportProfile? profile)
+        {
             if (item.Flags == null)
             {
                 item.Flags = new();
@@ -793,9 +799,10 @@ namespace Assets_Editor
 
                 w.Write((ushort)item.Flags.Market.TradeAsObjectId);
                 w.Write((ushort)item.Flags.Market.ShowAsObjectId);
-                w.Write((ushort)item.Name.Length);
-                for (UInt16 i = 0; i < item.Name.Length; ++i)
-                    w.Write((char)item.Name[i]);
+                var marketName = GetLegacyMarketName(item, profile);
+                w.Write((ushort)marketName.Length);
+                for (UInt16 i = 0; i < marketName.Length; ++i)
+                    w.Write((char)marketName[i]);
                 w.Write((ushort)item.Flags.Market.Vocation);
                 w.Write((ushort)item.Flags.Market.MinimumLevel);
             }
@@ -865,6 +872,17 @@ namespace Assets_Editor
                         w.Write((uint)0);
                 }
             }
+        }
+
+        private static string GetLegacyMarketName(Appearance item, LegacyAssetExportProfile? profile)
+        {
+            var marketName = item.Name ?? string.Empty;
+            if (profile?.MaxMarketNameLength > 0 && marketName.Length > profile.MaxMarketNameLength)
+            {
+                return marketName[..profile.MaxMarketNameLength];
+            }
+
+            return marketName;
         }
 
         public static int GetSpriteIndex(FrameGroup frameGroup, int width, int height, int layers, int patternX, int patternY, int patternZ, int frames)

--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -693,6 +693,8 @@ namespace Assets_Editor
                 MainWindow.Log("Export to 1098: missing flags for client id " + item.Id);
             }
 
+            var includeModernFlags = profile?.IncludeModernFlags ?? true;
+
             if (item.Flags.Bank != null)
             {
                 w.Write((byte)AppearanceFlag1098.Ground);
@@ -822,13 +824,13 @@ namespace Assets_Editor
             if (item.Flags.IgnoreLook)
                 w.Write((byte)AppearanceFlag1098.Lookthrough);
 
-            if (item.Flags.Clothes != null)
+            if (includeModernFlags && item.Flags.Clothes != null)
             {
                 w.Write((byte)AppearanceFlag1098.Clothes);
                 w.Write((ushort)item.Flags.Clothes.Slot);
             }
 
-            if (item.Flags.Market != null)
+            if (includeModernFlags && item.Flags.Market != null)
             {
                 w.Write((byte)AppearanceFlag1098.Market);
 
@@ -847,19 +849,19 @@ namespace Assets_Editor
                 w.Write((ushort)item.Flags.Market.MinimumLevel);
             }
 
-            if (item.Flags.DefaultAction != null)
+            if (includeModernFlags && item.Flags.DefaultAction != null)
             {
                 w.Write((byte)AppearanceFlag1098.DefaultAction);
                 w.Write((ushort)item.Flags.DefaultAction.Action);
             }
 
-            if (item.Flags.Wrap)
+            if (includeModernFlags && item.Flags.Wrap)
                 w.Write((byte)AppearanceFlag1098.Wrappable);
 
-            if (item.Flags.Unwrap)
+            if (includeModernFlags && item.Flags.Unwrap)
                 w.Write((byte)AppearanceFlag1098.UnWrappable);
 
-            if (item.Flags.Topeffect)
+            if (includeModernFlags && item.Flags.Topeffect)
                 w.Write((byte)AppearanceFlag1098.TopEffect);
 
             w.Write((byte)0xFF);

--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -254,30 +254,23 @@ namespace Assets_Editor
         {
             try
             {
-                var datFile = new FileStream(fn, FileMode.Create, FileAccess.Write);
+                using var datFile = new FileStream(fn, FileMode.Create, FileAccess.Write);
                 using (var w = new BinaryWriter(datFile, Encoding.GetEncoding("ISO-8859-1")))
                 {
+                    var objectCount = appearances.Object.Count > 0 ? appearances.Object.Max(item => item.Id) : 99;
+                    var outfitCount = appearances.Outfit.Count > 0 ? appearances.Outfit.Max(item => item.Id) : 0;
+                    var effectCount = appearances.Effect.Count > 0 ? appearances.Effect.Max(item => item.Id) : 0;
+                    var missileCount = appearances.Missile.Count > 0 ? appearances.Missile.Max(item => item.Id) : 0;
+
                     w.Write(profile.DatSignature);
-                    w.Write((ushort)(appearances.Object.Count + 99));
-                    w.Write((ushort)appearances.Outfit.Count);
-                    w.Write((ushort)appearances.Effect.Count);
-                    w.Write((ushort)appearances.Missile.Count);
-                    foreach (Appearance appearance in appearances.Object.OrderBy(item => item.Id))
-                    {
-                        WriteAppearance(w, appearance, profile);
-                    }
-                    foreach (Appearance appearance in appearances.Outfit.OrderBy(item => item.Id))
-                    {
-                        WriteAppearance(w, appearance, profile);
-                    }
-                    foreach (Appearance appearance in appearances.Effect.OrderBy(item => item.Id))
-                    {
-                        WriteAppearance(w, appearance, profile);
-                    }
-                    foreach (Appearance appearance in appearances.Missile.OrderBy(item => item.Id))
-                    {
-                        WriteAppearance(w, appearance, profile);
-                    }
+                    w.Write((ushort)objectCount);
+                    w.Write((ushort)outfitCount);
+                    w.Write((ushort)effectCount);
+                    w.Write((ushort)missileCount);
+                    WriteAppearanceRange(w, appearances.Object, profile, APPEARANCE_TYPE.AppearanceObject, 100, objectCount);
+                    WriteAppearanceRange(w, appearances.Outfit, profile, APPEARANCE_TYPE.AppearanceOutfit, 1, outfitCount);
+                    WriteAppearanceRange(w, appearances.Effect, profile, APPEARANCE_TYPE.AppearanceEffect, 1, effectCount);
+                    WriteAppearanceRange(w, appearances.Missile, profile, APPEARANCE_TYPE.AppearanceMissile, 1, missileCount);
 
                     return true;
                 }
@@ -286,6 +279,53 @@ namespace Assets_Editor
             {
                 return false;
             }
+        }
+
+        private static void WriteAppearanceRange(BinaryWriter w, Google.Protobuf.Collections.RepeatedField<Appearance> appearances, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint firstId, uint lastId)
+        {
+            if (lastId < firstId)
+            {
+                return;
+            }
+
+            var byId = appearances.ToDictionary(item => item.Id);
+            for (var id = firstId; id <= lastId; id++)
+            {
+                if (!byId.TryGetValue(id, out var appearance))
+                {
+                    appearance = new Appearance
+                    {
+                        Id = id,
+                        AppearanceType = type,
+                        Flags = new AppearanceFlags(),
+                    };
+                    appearance.FrameGroup.Add(CreateBlankFrameGroup());
+                }
+
+                appearance.AppearanceType = type;
+                WriteAppearance(w, appearance, profile);
+            }
+        }
+
+        private static FrameGroup CreateBlankFrameGroup()
+        {
+            var frameGroup = new FrameGroup
+            {
+                FixedFrameGroup = FIXED_FRAME_GROUP.OutfitIdle,
+                SpriteInfo = new SpriteInfo
+                {
+                    PatternWidth = 1,
+                    PatternHeight = 1,
+                    PatternSize = 32,
+                    PatternLayers = 1,
+                    PatternX = 1,
+                    PatternY = 1,
+                    PatternZ = 1,
+                    PatternFrames = 1,
+                },
+            };
+            frameGroup.SpriteInfo.SpriteId.Add(0);
+            return frameGroup;
         }
 
         private static void WriteAppearance(BinaryWriter w, Appearance appearance, LegacyAssetExportProfile profile)
@@ -824,46 +864,58 @@ namespace Assets_Editor
 
             w.Write((byte)0xFF);
 
+            var frameGroups = SelectFrameGroups1098(item, profile);
             if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
-                w.Write((byte)item.FrameGroup.Count);
+                w.Write((byte)frameGroups.Count);
 
-            for (int i = 0; i < item.FrameGroup.Count; i++)
+            for (int i = 0; i < frameGroups.Count; i++)
             {
-                FrameGroup frameGroup = item.FrameGroup[i];
+                FrameGroup frameGroup = frameGroups[i];
 
                 if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
                     w.Write((byte)frameGroup.FixedFrameGroup);
 
                 SpriteInfo spriteInfo = frameGroup.SpriteInfo;
-                byte width = (byte)spriteInfo.PatternWidth;
-                byte height = (byte)spriteInfo.PatternHeight;
+                byte width = ToNonZeroByte(spriteInfo.PatternWidth);
+                byte height = ToNonZeroByte(spriteInfo.PatternHeight);
 
                 w.Write(width);
                 w.Write(height);
 
                 if (width > 1 || height > 1)
-                    w.Write((byte)spriteInfo.PatternSize);
+                    w.Write(ToNonZeroByte(spriteInfo.PatternSize));
 
-                w.Write((byte)spriteInfo.PatternLayers);
-                w.Write((byte)spriteInfo.PatternX);
-                w.Write((byte)spriteInfo.PatternY);
-                w.Write((byte)spriteInfo.PatternZ);
-                w.Write((byte)spriteInfo.PatternFrames);
+                var animation = spriteInfo.Animation;
+                var includeEnhancedAnimations = profile?.IncludeEnhancedAnimations ?? true;
+                var frames = includeEnhancedAnimations && animation?.SpritePhase.Count > 0
+                    ? Math.Max(1, Math.Min(byte.MaxValue, animation.SpritePhase.Count))
+                    : Math.Max(1, Math.Min(byte.MaxValue, (int)spriteInfo.PatternFrames));
 
-                if (spriteInfo.PatternFrames > 1)
+                byte layers = ToNonZeroByte(spriteInfo.PatternLayers);
+                byte patternX = ToNonZeroByte(spriteInfo.PatternX);
+                byte patternY = ToNonZeroByte(spriteInfo.PatternY);
+                byte patternZ = ToNonZeroByte(spriteInfo.PatternZ);
+
+                w.Write(layers);
+                w.Write(patternX);
+                w.Write(patternY);
+                w.Write(patternZ);
+                w.Write((byte)frames);
+
+                if (includeEnhancedAnimations && frames > 1 && animation != null)
                 {
-                    w.Write(Convert.ToByte(spriteInfo.Animation.AnimationMode));
-                    w.Write(spriteInfo.Animation.LoopCount);
-                    w.Write((byte)spriteInfo.Animation.DefaultStartPhase);
+                    w.Write(Convert.ToByte(animation.AnimationMode));
+                    w.Write(animation.LoopCount);
+                    w.Write((byte)animation.DefaultStartPhase);
 
-                    for (int k = 0; k < spriteInfo.Animation.SpritePhase.Count; k++)
+                    for (int k = 0; k < frames; k++)
                     {
-                        w.Write(spriteInfo.Animation.SpritePhase[k].DurationMin);
-                        w.Write(spriteInfo.Animation.SpritePhase[k].DurationMax);
+                        w.Write(animation.SpritePhase[k].DurationMin);
+                        w.Write(animation.SpritePhase[k].DurationMax);
                     }
                 }
 
-                uint numSprites = spriteInfo.PatternWidth * spriteInfo.PatternHeight * spriteInfo.PatternLayers * spriteInfo.PatternX * spriteInfo.PatternY * spriteInfo.PatternZ * spriteInfo.PatternFrames;
+                uint numSprites = (uint)width * height * layers * patternX * patternY * patternZ * (uint)frames;
                 for (var x = 0; x < numSprites; x++)
                 {
                     if (x < spriteInfo.SpriteId.Count)
@@ -872,6 +924,26 @@ namespace Assets_Editor
                         w.Write((uint)0);
                 }
             }
+        }
+
+        private static System.Collections.Generic.IReadOnlyList<FrameGroup> SelectFrameGroups1098(Appearance item, LegacyAssetExportProfile? profile)
+        {
+            if (item.FrameGroup.Count == 0)
+            {
+                return [CreateBlankFrameGroup()];
+            }
+
+            if (item.AppearanceType != APPEARANCE_TYPE.AppearanceOutfit || profile?.IncludeFrameGroups == false)
+            {
+                return [item.FrameGroup[0]];
+            }
+
+            return item.FrameGroup.Take(byte.MaxValue).ToArray();
+        }
+
+        private static byte ToNonZeroByte(uint value)
+        {
+            return (byte)Math.Max(1, Math.Min(byte.MaxValue, value));
         }
 
         private static string GetLegacyMarketName(Appearance item, LegacyAssetExportProfile? profile)

--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -245,6 +245,7 @@ namespace Assets_Editor
                 IncludeEnhancedAnimations = true,
                 IncludeFrameGroups = true,
                 IncludeModernFlags = true,
+                LegacyOutfitAnimationFrames = 0,
             }, appearances);
         }
 
@@ -430,10 +431,10 @@ namespace Assets_Editor
             }
 
             w.Write((byte)AppearanceFlag860.Default);
-            WriteSpriteInfo860(w, SelectLegacyFrameGroup(item).SpriteInfo, profile);
+            WriteSpriteInfo860(w, SelectLegacyFrameGroup860(item, profile).SpriteInfo, profile);
         }
 
-        private static FrameGroup SelectLegacyFrameGroup(Appearance item)
+        private static FrameGroup SelectLegacyFrameGroup860(Appearance item, LegacyAssetExportProfile profile)
         {
             if (item.FrameGroup.Count == 0)
             {
@@ -458,14 +459,146 @@ namespace Assets_Editor
 
             if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
             {
+                var mergedGroup = TryCreateLegacy860OutfitGroup(item, profile);
+                if (mergedGroup != null)
+                {
+                    return mergedGroup;
+                }
+
                 var movingGroup = item.FrameGroup.FirstOrDefault(group => group.FixedFrameGroup == FIXED_FRAME_GROUP.OutfitMoving);
                 if (movingGroup != null)
                 {
-                    return movingGroup;
+                    return LimitLegacy860OutfitFrameCount(movingGroup, profile);
                 }
             }
 
             return item.FrameGroup[0];
+        }
+
+        private static FrameGroup TryCreateLegacy860OutfitGroup(Appearance item, LegacyAssetExportProfile profile)
+        {
+            var idleGroup = item.FrameGroup.FirstOrDefault(group => group.FixedFrameGroup == FIXED_FRAME_GROUP.OutfitIdle) ?? item.FrameGroup[0];
+            var movingGroup = item.FrameGroup.FirstOrDefault(group => group.FixedFrameGroup == FIXED_FRAME_GROUP.OutfitMoving);
+            if (movingGroup?.SpriteInfo == null || idleGroup?.SpriteInfo == null)
+            {
+                return null;
+            }
+
+            var idleInfo = idleGroup.SpriteInfo;
+            var movingInfo = movingGroup.SpriteInfo;
+            if (!CanMergeLegacy860OutfitGroups(idleInfo, movingInfo))
+            {
+                return null;
+            }
+
+            var frameSpriteCount = GetLegacyFrameSpriteCount(movingInfo);
+            if (frameSpriteCount == 0)
+            {
+                return null;
+            }
+
+            var movingFrames = Math.Max(1, (int)Math.Min(byte.MaxValue, movingInfo.PatternFrames));
+            var frameCount = profile.LegacyOutfitAnimationFrames > 0
+                ? Math.Clamp(profile.LegacyOutfitAnimationFrames, 1, byte.MaxValue)
+                : 1 + Math.Min(movingFrames, byte.MaxValue - 1);
+            var movingFramesToWrite = Math.Max(0, frameCount - 1);
+
+            var spriteInfo = movingInfo.Clone();
+            spriteInfo.Animation = null;
+            spriteInfo.PatternFrames = (uint)frameCount;
+            spriteInfo.SpriteId.Clear();
+
+            AddLegacyFrameSprites(spriteInfo.SpriteId, idleInfo, 0, frameSpriteCount);
+            for (var frame = 0; frame < movingFramesToWrite; frame++)
+            {
+                AddLegacyFrameSprites(spriteInfo.SpriteId, movingInfo, GetSampledMovingFrame(frame, movingFramesToWrite, movingFrames), frameSpriteCount);
+            }
+
+            return new FrameGroup
+            {
+                FixedFrameGroup = FIXED_FRAME_GROUP.OutfitIdle,
+                SpriteInfo = spriteInfo,
+            };
+        }
+
+        private static int GetSampledMovingFrame(int targetFrame, int targetFrameCount, int sourceFrameCount)
+        {
+            if (targetFrameCount <= 1 || sourceFrameCount <= 1)
+            {
+                return 0;
+            }
+
+            return Math.Min(sourceFrameCount - 1, targetFrame * sourceFrameCount / targetFrameCount);
+        }
+
+        private static FrameGroup LimitLegacy860OutfitFrameCount(FrameGroup frameGroup, LegacyAssetExportProfile profile)
+        {
+            if (profile.LegacyOutfitAnimationFrames <= 0 || frameGroup.SpriteInfo == null)
+            {
+                return frameGroup;
+            }
+
+            var spriteInfo = frameGroup.SpriteInfo;
+            var sourceFrames = Math.Max(1, (int)Math.Min(byte.MaxValue, spriteInfo.PatternFrames));
+            var frameCount = Math.Clamp(profile.LegacyOutfitAnimationFrames, 1, byte.MaxValue);
+            if (sourceFrames <= frameCount)
+            {
+                return frameGroup;
+            }
+
+            var frameSpriteCount = GetLegacyFrameSpriteCount(spriteInfo);
+            if (frameSpriteCount == 0)
+            {
+                return frameGroup;
+            }
+
+            var limitedInfo = spriteInfo.Clone();
+            limitedInfo.Animation = null;
+            limitedInfo.PatternFrames = (uint)frameCount;
+            limitedInfo.SpriteId.Clear();
+
+            for (var frame = 0; frame < frameCount; frame++)
+            {
+                AddLegacyFrameSprites(limitedInfo.SpriteId, spriteInfo, GetSampledMovingFrame(frame, frameCount, sourceFrames), frameSpriteCount);
+            }
+
+            return new FrameGroup
+            {
+                FixedFrameGroup = frameGroup.FixedFrameGroup,
+                SpriteInfo = limitedInfo,
+            };
+        }
+
+        private static bool CanMergeLegacy860OutfitGroups(SpriteInfo idleInfo, SpriteInfo movingInfo)
+        {
+            return idleInfo.PatternWidth == movingInfo.PatternWidth
+                && idleInfo.PatternHeight == movingInfo.PatternHeight
+                && idleInfo.PatternLayers == movingInfo.PatternLayers
+                && idleInfo.PatternX == movingInfo.PatternX
+                && idleInfo.PatternY == movingInfo.PatternY
+                && idleInfo.PatternZ == movingInfo.PatternZ;
+        }
+
+        private static int GetLegacyFrameSpriteCount(SpriteInfo spriteInfo)
+        {
+            return (int)(Math.Max(1, (int)spriteInfo.PatternWidth)
+                * Math.Max(1, (int)spriteInfo.PatternHeight)
+                * Math.Max(1, (int)spriteInfo.PatternLayers)
+                * Math.Max(1, (int)spriteInfo.PatternX)
+                * Math.Max(1, (int)spriteInfo.PatternY)
+                * Math.Max(1, (int)spriteInfo.PatternZ));
+        }
+
+        private static void AddLegacyFrameSprites(Google.Protobuf.Collections.RepeatedField<uint> target, SpriteInfo source, int frame, int frameSpriteCount)
+        {
+            var sourceFrames = Math.Max(1, (int)source.PatternFrames);
+            var selectedFrame = Math.Min(Math.Max(frame, 0), sourceFrames - 1);
+            var offset = selectedFrame * frameSpriteCount;
+            for (var index = 0; index < frameSpriteCount; index++)
+            {
+                var sourceIndex = offset + index;
+                target.Add(sourceIndex < source.SpriteId.Count ? source.SpriteId[sourceIndex] : 0);
+            }
         }
 
         private static void WriteSpriteInfo860(BinaryWriter w, SpriteInfo spriteInfo, LegacyAssetExportProfile profile)

--- a/Assets Editor/LegacyAppearance.cs
+++ b/Assets Editor/LegacyAppearance.cs
@@ -4,10 +4,94 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Text;
 using Tibia.Protobuf.Appearances;
 
 namespace Assets_Editor
 {
+    enum AppearanceFlag1098 : byte
+    {
+        Ground = 0,
+        Clip = 1,
+        Bottom = 2,
+        Top = 3,
+        Container = 4,
+        Stackable = 5,
+        ForceUse = 6,
+        Usable = 254,
+        Multiuse = 7,
+        Writeable = 8,
+        WriteableOnce = 9,
+        LiquidContainer = 10,
+        LiquidPool = 11,
+        Impassable = 12,
+        Unmovable = 13,
+        BlocksSight = 14,
+        BlocksPathfinding = 15,
+        NoMovementAnimation = 16,
+        Pickupable = 17,
+        Hangable = 18,
+        HooksSouth = 19,
+        HooksEast = 20,
+        Rotateable = 21,
+        LightSource = 22,
+        AlwaysSeen = 23,
+        Translucent = 24,
+        Displaced = 25,
+        Elevated = 26,
+        LyingObject = 27,
+        AlwaysAnimated = 28,
+        MinimapColor = 29,
+        HelpInfo = 30,
+        FullTile = 31,
+        Lookthrough = 32,
+        Clothes = 33,
+        Market = 34,
+        DefaultAction = 35,
+        Wrappable = 36,
+        UnWrappable = 37,
+        TopEffect = 38,
+        Default = 255
+    }
+
+    enum AppearanceFlag860 : byte
+    {
+        Ground = 0,
+        Clip = 1,
+        Bottom = 2,
+        Top = 3,
+        Container = 4,
+        Stackable = 5,
+        ForceUse = 6,
+        Multiuse = 7,
+        Writeable = 8,
+        WriteableOnce = 9,
+        LiquidContainer = 10,
+        LiquidPool = 11,
+        Impassable = 12,
+        Unmovable = 13,
+        BlocksSight = 14,
+        BlocksPathfinding = 15,
+        Pickupable = 16,
+        Hangable = 17,
+        HooksSouth = 18,
+        HooksEast = 19,
+        Rotateable = 20,
+        LightSource = 21,
+        AlwaysSeen = 22,
+        Translucent = 23,
+        Displaced = 24,
+        Elevated = 25,
+        LyingObject = 26,
+        AlwaysAnimated = 27,
+        MinimapColor = 28,
+        HelpInfo = 29,
+        FullTile = 30,
+        Lookthrough = 31,
+        Clothes = 32,
+        Default = 255
+    }
+
     public class LegacyAppearance
     {
         public LegacyAppearance()
@@ -144,6 +228,509 @@ namespace Assets_Editor
             {
                 ErrorManager.ShowError(exception.Message);
                 return false;
+            }
+        }
+
+        public static bool WriteLegacyDat(string fn, uint signature, Appearances appearances)
+        {
+            return WriteLegacyDat(fn, new LegacyAssetExportProfile
+            {
+                Id = "legacy1098-custom",
+                DisplayName = "Legacy 10.98 compatible",
+                DatLayout = LegacyDatLayout.Tibia1098,
+                DatSignature = signature,
+                SprSignature = 0,
+                Transparency = false,
+                SpriteIdsU32 = true,
+                IncludeEnhancedAnimations = true,
+                IncludeFrameGroups = true,
+                IncludeModernFlags = true,
+            }, appearances);
+        }
+
+        public static bool WriteLegacyDat(string fn, LegacyAssetExportProfile profile, Appearances appearances)
+        {
+            try
+            {
+                var datFile = new FileStream(fn, FileMode.Create, FileAccess.Write);
+                using (var w = new BinaryWriter(datFile, Encoding.GetEncoding("ISO-8859-1")))
+                {
+                    w.Write(profile.DatSignature);
+                    w.Write((ushort)(appearances.Object.Count + 99));
+                    w.Write((ushort)appearances.Outfit.Count);
+                    w.Write((ushort)appearances.Effect.Count);
+                    w.Write((ushort)appearances.Missile.Count);
+                    foreach (Appearance appearance in appearances.Object.OrderBy(item => item.Id))
+                    {
+                        WriteAppearance(w, appearance, profile);
+                    }
+                    foreach (Appearance appearance in appearances.Outfit.OrderBy(item => item.Id))
+                    {
+                        WriteAppearance(w, appearance, profile);
+                    }
+                    foreach (Appearance appearance in appearances.Effect.OrderBy(item => item.Id))
+                    {
+                        WriteAppearance(w, appearance, profile);
+                    }
+                    foreach (Appearance appearance in appearances.Missile.OrderBy(item => item.Id))
+                    {
+                        WriteAppearance(w, appearance, profile);
+                    }
+
+                    return true;
+                }
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+        }
+
+        private static void WriteAppearance(BinaryWriter w, Appearance appearance, LegacyAssetExportProfile profile)
+        {
+            if (profile.DatLayout == LegacyDatLayout.Tibia860)
+            {
+                WriteAppearance860(w, appearance, profile);
+                return;
+            }
+
+            WriteAppearance1098(w, appearance);
+        }
+
+        public static void WriteAppearance860(BinaryWriter w, Appearance item, LegacyAssetExportProfile profile)
+        {
+            item.Flags ??= new AppearanceFlags();
+
+            if (item.Flags.Bank != null)
+            {
+                w.Write((byte)AppearanceFlag860.Ground);
+                w.Write((ushort)(item.Flags.Bank.HasWaypoints ? item.Flags.Bank.Waypoints : 0));
+            }
+
+            if (item.Flags.Clip)
+                w.Write((byte)AppearanceFlag860.Clip);
+
+            if (item.Flags.Top)
+                w.Write((byte)AppearanceFlag860.Top);
+
+            if (item.Flags.Bottom)
+                w.Write((byte)AppearanceFlag860.Bottom);
+
+            if (item.Flags.Container)
+                w.Write((byte)AppearanceFlag860.Container);
+
+            if (item.Flags.Cumulative)
+                w.Write((byte)AppearanceFlag860.Stackable);
+
+            if (item.Flags.Forceuse || item.Flags.Usable)
+                w.Write((byte)AppearanceFlag860.ForceUse);
+
+            if (item.Flags.Multiuse)
+                w.Write((byte)AppearanceFlag860.Multiuse);
+
+            if (item.Flags.Write != null)
+            {
+                w.Write((byte)AppearanceFlag860.Writeable);
+                w.Write((ushort)item.Flags.Write.MaxTextLength);
+            }
+
+            if (item.Flags.WriteOnce != null)
+            {
+                w.Write((byte)AppearanceFlag860.WriteableOnce);
+                w.Write((ushort)item.Flags.WriteOnce.MaxTextLengthOnce);
+            }
+
+            if (item.Flags.Liquidcontainer)
+                w.Write((byte)AppearanceFlag860.LiquidContainer);
+
+            if (item.Flags.Liquidpool)
+                w.Write((byte)AppearanceFlag860.LiquidPool);
+
+            if (item.Flags.Unpass)
+                w.Write((byte)AppearanceFlag860.Impassable);
+
+            if (item.Flags.Unmove)
+                w.Write((byte)AppearanceFlag860.Unmovable);
+
+            if (item.Flags.Unsight)
+                w.Write((byte)AppearanceFlag860.BlocksSight);
+
+            if (item.Flags.Avoid)
+                w.Write((byte)AppearanceFlag860.BlocksPathfinding);
+
+            if (item.Flags.Take)
+                w.Write((byte)AppearanceFlag860.Pickupable);
+
+            if (item.Flags.Hang)
+                w.Write((byte)AppearanceFlag860.Hangable);
+
+            if (item.Flags.HookSouth)
+                w.Write((byte)AppearanceFlag860.HooksSouth);
+
+            if (item.Flags.HookEast)
+                w.Write((byte)AppearanceFlag860.HooksEast);
+
+            if (item.Flags.Rotate)
+                w.Write((byte)AppearanceFlag860.Rotateable);
+
+            if (item.Flags.Light != null)
+            {
+                w.Write((byte)AppearanceFlag860.LightSource);
+                w.Write((ushort)item.Flags.Light.Brightness);
+                w.Write((ushort)item.Flags.Light.Color);
+            }
+
+            if (item.Flags.DontHide)
+                w.Write((byte)AppearanceFlag860.AlwaysSeen);
+
+            if (item.Flags.Translucent)
+                w.Write((byte)AppearanceFlag860.Translucent);
+
+            if (item.Flags.Shift != null)
+            {
+                w.Write((byte)AppearanceFlag860.Displaced);
+                w.Write((ushort)item.Flags.Shift.X);
+                w.Write((ushort)item.Flags.Shift.Y);
+            }
+
+            if (item.Flags.Height != null)
+            {
+                w.Write((byte)AppearanceFlag860.Elevated);
+                w.Write((ushort)item.Flags.Height.Elevation);
+            }
+
+            if (item.Flags.LyingObject)
+                w.Write((byte)AppearanceFlag860.LyingObject);
+
+            if (item.Flags.AnimateAlways)
+                w.Write((byte)AppearanceFlag860.AlwaysAnimated);
+
+            if (item.Flags.Automap != null)
+            {
+                w.Write((byte)AppearanceFlag860.MinimapColor);
+                w.Write((ushort)item.Flags.Automap.Color);
+            }
+
+            if (item.Flags.Lenshelp != null)
+            {
+                w.Write((byte)AppearanceFlag860.HelpInfo);
+                w.Write((ushort)item.Flags.Lenshelp.Id);
+            }
+
+            if (item.Flags.Fullbank)
+                w.Write((byte)AppearanceFlag860.FullTile);
+
+            if (item.Flags.IgnoreLook)
+                w.Write((byte)AppearanceFlag860.Lookthrough);
+
+            if (profile.IncludeModernFlags && item.Flags.Clothes != null)
+            {
+                w.Write((byte)AppearanceFlag860.Clothes);
+                w.Write((ushort)item.Flags.Clothes.Slot);
+            }
+
+            w.Write((byte)AppearanceFlag860.Default);
+            WriteSpriteInfo860(w, SelectLegacyFrameGroup(item).SpriteInfo, profile);
+        }
+
+        private static FrameGroup SelectLegacyFrameGroup(Appearance item)
+        {
+            if (item.FrameGroup.Count == 0)
+            {
+                var frameGroup = new FrameGroup
+                {
+                    FixedFrameGroup = FIXED_FRAME_GROUP.OutfitIdle,
+                    SpriteInfo = new SpriteInfo
+                    {
+                        PatternWidth = 1,
+                        PatternHeight = 1,
+                        PatternSize = 32,
+                        PatternLayers = 1,
+                        PatternX = 1,
+                        PatternY = 1,
+                        PatternZ = 1,
+                        PatternFrames = 1,
+                    }
+                };
+                frameGroup.SpriteInfo.SpriteId.Add(0);
+                return frameGroup;
+            }
+
+            if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
+            {
+                var movingGroup = item.FrameGroup.FirstOrDefault(group => group.FixedFrameGroup == FIXED_FRAME_GROUP.OutfitMoving);
+                if (movingGroup != null)
+                {
+                    return movingGroup;
+                }
+            }
+
+            return item.FrameGroup[0];
+        }
+
+        private static void WriteSpriteInfo860(BinaryWriter w, SpriteInfo spriteInfo, LegacyAssetExportProfile profile)
+        {
+            byte width = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternWidth));
+            byte height = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternHeight));
+
+            w.Write(width);
+            w.Write(height);
+
+            if (width > 1 || height > 1)
+                w.Write((byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternSize)));
+
+            byte layers = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternLayers));
+            byte patternX = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternX));
+            byte patternY = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternY));
+            byte patternZ = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternZ));
+            byte frames = (byte)Math.Max(1, Math.Min(byte.MaxValue, spriteInfo.PatternFrames));
+
+            w.Write(layers);
+            w.Write(patternX);
+            w.Write(patternY);
+            w.Write(patternZ);
+            w.Write(frames);
+
+            var numSprites = width * height * layers * patternX * patternY * patternZ * frames;
+            for (var i = 0; i < numSprites; i++)
+            {
+                var spriteId = i < spriteInfo.SpriteId.Count ? spriteInfo.SpriteId[i] : 0;
+                if (profile.SpriteIdsU32)
+                {
+                    w.Write(spriteId);
+                }
+                else
+                {
+                    w.Write((ushort)Math.Min(ushort.MaxValue, spriteId));
+                }
+            }
+        }
+
+        public static void WriteAppearance1098(BinaryWriter w, Appearance item)
+        {
+            if (item.Flags == null)
+            {
+                item.Flags = new();
+                MainWindow.Log("Export to 1098: missing flags for client id " + item.Id);
+            }
+
+            if (item.Flags.Bank != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Ground);
+                if (item.Flags.Bank.HasWaypoints)
+                    w.Write((ushort)item.Flags.Bank.Waypoints);
+            }
+
+            if (item.Flags.Clip)
+                w.Write((byte)AppearanceFlag1098.Clip);
+
+            if (item.Flags.Top)
+                w.Write((byte)AppearanceFlag1098.Top);
+
+            if (item.Flags.Bottom)
+                w.Write((byte)AppearanceFlag1098.Bottom);
+
+            if (item.Flags.Container)
+                w.Write((byte)AppearanceFlag1098.Container);
+
+            if (item.Flags.Cumulative)
+                w.Write((byte)AppearanceFlag1098.Stackable);
+
+            if (item.Flags.Forceuse)
+                w.Write((byte)AppearanceFlag1098.ForceUse);
+
+            if (item.Flags.Usable)
+                w.Write((byte)AppearanceFlag1098.Usable);
+
+            if (item.Flags.Multiuse)
+                w.Write((byte)AppearanceFlag1098.Multiuse);
+
+            if (item.Flags.Write != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Writeable);
+                w.Write((ushort)item.Flags.Write.MaxTextLength);
+            }
+
+            if (item.Flags.WriteOnce != null)
+            {
+                w.Write((byte)AppearanceFlag1098.WriteableOnce);
+                w.Write((ushort)item.Flags.WriteOnce.MaxTextLengthOnce);
+            }
+
+            if (item.Flags.Liquidpool)
+                w.Write((byte)AppearanceFlag1098.LiquidPool);
+
+            if (item.Flags.Liquidcontainer)
+                w.Write((byte)AppearanceFlag1098.LiquidContainer);
+
+            if (item.Flags.Unpass)
+                w.Write((byte)AppearanceFlag1098.Impassable);
+
+            if (item.Flags.Unmove)
+                w.Write((byte)AppearanceFlag1098.Unmovable);
+
+            if (item.Flags.Unsight)
+                w.Write((byte)AppearanceFlag1098.BlocksSight);
+
+            if (item.Flags.Avoid)
+                w.Write((byte)AppearanceFlag1098.BlocksPathfinding);
+
+            if (item.Flags.NoMovementAnimation)
+                w.Write((byte)AppearanceFlag1098.NoMovementAnimation);
+
+            if (item.Flags.Take)
+                w.Write((byte)AppearanceFlag1098.Pickupable);
+
+            if (item.Flags.Hang)
+                w.Write((byte)AppearanceFlag1098.Hangable);
+
+            if (item.Flags.HookSouth)
+                w.Write((byte)AppearanceFlag1098.HooksSouth);
+
+            if (item.Flags.HookEast)
+                w.Write((byte)AppearanceFlag1098.HooksEast);
+
+            if (item.Flags.Rotate)
+                w.Write((byte)AppearanceFlag1098.Rotateable);
+
+            if (item.Flags.Light != null)
+            {
+                w.Write((byte)AppearanceFlag1098.LightSource);
+                w.Write((ushort)item.Flags.Light.Brightness);
+                w.Write((ushort)item.Flags.Light.Color);
+            }
+
+            if (item.Flags.DontHide)
+                w.Write((byte)AppearanceFlag1098.AlwaysSeen);
+
+            if (item.Flags.Translucent)
+                w.Write((byte)AppearanceFlag1098.Translucent);
+
+            if (item.Flags.Shift != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Displaced);
+                w.Write((ushort)item.Flags.Shift.X);
+                w.Write((ushort)item.Flags.Shift.Y);
+            }
+
+            if (item.Flags.Height != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Elevated);
+                w.Write((ushort)item.Flags.Height.Elevation);
+            }
+
+            if (item.Flags.LyingObject)
+                w.Write((byte)AppearanceFlag1098.LyingObject);
+
+            if (item.Flags.AnimateAlways)
+                w.Write((byte)AppearanceFlag1098.AlwaysAnimated);
+
+            if (item.Flags.Automap != null)
+            {
+                w.Write((byte)AppearanceFlag1098.MinimapColor);
+                w.Write((ushort)item.Flags.Automap.Color);
+            }
+
+            if (item.Flags.Fullbank)
+                w.Write((byte)AppearanceFlag1098.FullTile);
+
+            if (item.Flags.Lenshelp != null)
+            {
+                w.Write((byte)AppearanceFlag1098.HelpInfo);
+                w.Write((ushort)item.Flags.Lenshelp.Id);
+            }
+
+            if (item.Flags.IgnoreLook)
+                w.Write((byte)AppearanceFlag1098.Lookthrough);
+
+            if (item.Flags.Clothes != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Clothes);
+                w.Write((ushort)item.Flags.Clothes.Slot);
+            }
+
+            if (item.Flags.Market != null)
+            {
+                w.Write((byte)AppearanceFlag1098.Market);
+
+                ushort category = (ushort)item.Flags.Market.Category;
+                if (category > 22)
+                    category = 9;
+                w.Write(category);
+
+                w.Write((ushort)item.Flags.Market.TradeAsObjectId);
+                w.Write((ushort)item.Flags.Market.ShowAsObjectId);
+                w.Write((ushort)item.Name.Length);
+                for (UInt16 i = 0; i < item.Name.Length; ++i)
+                    w.Write((char)item.Name[i]);
+                w.Write((ushort)item.Flags.Market.Vocation);
+                w.Write((ushort)item.Flags.Market.MinimumLevel);
+            }
+
+            if (item.Flags.DefaultAction != null)
+            {
+                w.Write((byte)AppearanceFlag1098.DefaultAction);
+                w.Write((ushort)item.Flags.DefaultAction.Action);
+            }
+
+            if (item.Flags.Wrap)
+                w.Write((byte)AppearanceFlag1098.Wrappable);
+
+            if (item.Flags.Unwrap)
+                w.Write((byte)AppearanceFlag1098.UnWrappable);
+
+            if (item.Flags.Topeffect)
+                w.Write((byte)AppearanceFlag1098.TopEffect);
+
+            w.Write((byte)0xFF);
+
+            if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
+                w.Write((byte)item.FrameGroup.Count);
+
+            for (int i = 0; i < item.FrameGroup.Count; i++)
+            {
+                FrameGroup frameGroup = item.FrameGroup[i];
+
+                if (item.AppearanceType == APPEARANCE_TYPE.AppearanceOutfit)
+                    w.Write((byte)frameGroup.FixedFrameGroup);
+
+                SpriteInfo spriteInfo = frameGroup.SpriteInfo;
+                byte width = (byte)spriteInfo.PatternWidth;
+                byte height = (byte)spriteInfo.PatternHeight;
+
+                w.Write(width);
+                w.Write(height);
+
+                if (width > 1 || height > 1)
+                    w.Write((byte)spriteInfo.PatternSize);
+
+                w.Write((byte)spriteInfo.PatternLayers);
+                w.Write((byte)spriteInfo.PatternX);
+                w.Write((byte)spriteInfo.PatternY);
+                w.Write((byte)spriteInfo.PatternZ);
+                w.Write((byte)spriteInfo.PatternFrames);
+
+                if (spriteInfo.PatternFrames > 1)
+                {
+                    w.Write(Convert.ToByte(spriteInfo.Animation.AnimationMode));
+                    w.Write(spriteInfo.Animation.LoopCount);
+                    w.Write((byte)spriteInfo.Animation.DefaultStartPhase);
+
+                    for (int k = 0; k < spriteInfo.Animation.SpritePhase.Count; k++)
+                    {
+                        w.Write(spriteInfo.Animation.SpritePhase[k].DurationMin);
+                        w.Write(spriteInfo.Animation.SpritePhase[k].DurationMax);
+                    }
+                }
+
+                uint numSprites = spriteInfo.PatternWidth * spriteInfo.PatternHeight * spriteInfo.PatternLayers * spriteInfo.PatternX * spriteInfo.PatternY * spriteInfo.PatternZ * spriteInfo.PatternFrames;
+                for (var x = 0; x < numSprites; x++)
+                {
+                    if (x < spriteInfo.SpriteId.Count)
+                        w.Write(spriteInfo.SpriteId[(int)x]);
+                    else
+                        w.Write((uint)0);
+                }
             }
         }
 

--- a/Assets Editor/LegacyAssetExportProfile.cs
+++ b/Assets Editor/LegacyAssetExportProfile.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assets_Editor
+{
+    public enum LegacyDatLayout
+    {
+        Tibia860,
+        Tibia1098,
+    }
+
+    public sealed class LegacyAssetExportProfile
+    {
+        public required string Id { get; init; }
+        public required string DisplayName { get; init; }
+        public required LegacyDatLayout DatLayout { get; init; }
+        public required uint DatSignature { get; init; }
+        public required uint SprSignature { get; init; }
+        public required bool Transparency { get; init; }
+        public required bool SpriteIdsU32 { get; init; }
+        public required bool IncludeEnhancedAnimations { get; init; }
+        public required bool IncludeFrameGroups { get; init; }
+        public required bool IncludeModernFlags { get; init; }
+    }
+
+    public static class LegacyAssetExportProfiles
+    {
+        private static readonly LegacyAssetExportProfile[] Profiles =
+        [
+            new LegacyAssetExportProfile
+            {
+                Id = "cip860-extended",
+                DisplayName = "CipSoft 8.60 extended",
+                DatLayout = LegacyDatLayout.Tibia860,
+                DatSignature = 0x4C2C7993,
+                SprSignature = 0x4C220594,
+                Transparency = false,
+                SpriteIdsU32 = true,
+                IncludeEnhancedAnimations = false,
+                IncludeFrameGroups = false,
+                IncludeModernFlags = false,
+            },
+            new LegacyAssetExportProfile
+            {
+                Id = "canary860-extended",
+                DisplayName = "Canary 8.60 extended",
+                DatLayout = LegacyDatLayout.Tibia860,
+                DatSignature = 0x4C2C7993,
+                SprSignature = 0x4C220594,
+                Transparency = false,
+                SpriteIdsU32 = true,
+                IncludeEnhancedAnimations = false,
+                IncludeFrameGroups = false,
+                IncludeModernFlags = false,
+            },
+            new LegacyAssetExportProfile
+            {
+                Id = "legacy1098",
+                DisplayName = "Legacy 10.98 compatible",
+                DatLayout = LegacyDatLayout.Tibia1098,
+                DatSignature = 0x000042A3,
+                SprSignature = 0x53159CA9,
+                Transparency = false,
+                SpriteIdsU32 = true,
+                IncludeEnhancedAnimations = true,
+                IncludeFrameGroups = true,
+                IncludeModernFlags = true,
+            },
+        ];
+
+        public static IReadOnlyList<LegacyAssetExportProfile> All => Profiles;
+
+        public static LegacyAssetExportProfile Get(string id)
+        {
+            foreach (var profile in Profiles)
+            {
+                if (string.Equals(profile.Id, id, StringComparison.OrdinalIgnoreCase))
+                {
+                    return profile;
+                }
+            }
+
+            if (string.Equals(id, "860", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(id, "cip860", StringComparison.OrdinalIgnoreCase))
+            {
+                return Get("cip860-extended");
+            }
+
+            if (string.Equals(id, "1098", StringComparison.OrdinalIgnoreCase))
+            {
+                return Get("legacy1098");
+            }
+
+            throw new ArgumentException($"Unknown export profile '{id}'. Use --list-profiles to see valid profiles.");
+        }
+    }
+}

--- a/Assets Editor/LegacyAssetExportProfile.cs
+++ b/Assets Editor/LegacyAssetExportProfile.cs
@@ -13,6 +13,7 @@ namespace Assets_Editor
     {
         public required string Id { get; init; }
         public required string DisplayName { get; init; }
+        public required string Description { get; init; }
         public required LegacyDatLayout DatLayout { get; init; }
         public required uint DatSignature { get; init; }
         public required uint SprSignature { get; init; }
@@ -32,6 +33,7 @@ namespace Assets_Editor
             {
                 Id = "cip860-extended",
                 DisplayName = "CipSoft 8.60 extended",
+                Description = "8.60 dat layout with extended uint32 sprite ids; does not write modern dat flags such as Clothes/attr 32.",
                 DatLayout = LegacyDatLayout.Tibia860,
                 DatSignature = 0x4C2C7993,
                 SprSignature = 0x4C220594,
@@ -46,6 +48,7 @@ namespace Assets_Editor
             {
                 Id = "canary860-extended",
                 DisplayName = "Canary 8.60 extended",
+                Description = "Alias profile for Canary's CipSoft 8.60 extended client contract.",
                 DatLayout = LegacyDatLayout.Tibia860,
                 DatSignature = 0x4C2C7993,
                 SprSignature = 0x4C220594,
@@ -60,6 +63,7 @@ namespace Assets_Editor
             {
                 Id = "legacy1098",
                 DisplayName = "Legacy 10.98 compatible",
+                Description = "10.98-compatible spr/dat export with modern legacy flags enabled.",
                 DatLayout = LegacyDatLayout.Tibia1098,
                 DatSignature = 0x000042A3,
                 SprSignature = 0x53159CA9,

--- a/Assets Editor/LegacyAssetExportProfile.cs
+++ b/Assets Editor/LegacyAssetExportProfile.cs
@@ -21,6 +21,7 @@ namespace Assets_Editor
         public required bool IncludeEnhancedAnimations { get; init; }
         public required bool IncludeFrameGroups { get; init; }
         public required bool IncludeModernFlags { get; init; }
+        public required int LegacyOutfitAnimationFrames { get; init; }
     }
 
     public static class LegacyAssetExportProfiles
@@ -39,6 +40,7 @@ namespace Assets_Editor
                 IncludeEnhancedAnimations = false,
                 IncludeFrameGroups = false,
                 IncludeModernFlags = false,
+                LegacyOutfitAnimationFrames = 3,
             },
             new LegacyAssetExportProfile
             {
@@ -52,6 +54,7 @@ namespace Assets_Editor
                 IncludeEnhancedAnimations = false,
                 IncludeFrameGroups = false,
                 IncludeModernFlags = false,
+                LegacyOutfitAnimationFrames = 3,
             },
             new LegacyAssetExportProfile
             {
@@ -65,6 +68,7 @@ namespace Assets_Editor
                 IncludeEnhancedAnimations = true,
                 IncludeFrameGroups = true,
                 IncludeModernFlags = true,
+                LegacyOutfitAnimationFrames = 0,
             },
         ];
 

--- a/Assets Editor/LegacyAssetExportProfile.cs
+++ b/Assets Editor/LegacyAssetExportProfile.cs
@@ -23,6 +23,7 @@ namespace Assets_Editor
         public required bool IncludeFrameGroups { get; init; }
         public required bool IncludeModernFlags { get; init; }
         public required int LegacyOutfitAnimationFrames { get; init; }
+        public int MaxMarketNameLength { get; init; }
     }
 
     public static class LegacyAssetExportProfiles
@@ -74,6 +75,22 @@ namespace Assets_Editor
                 IncludeModernFlags = true,
                 LegacyOutfitAnimationFrames = 0,
             },
+            new LegacyAssetExportProfile
+            {
+                Id = "client11-15x",
+                DisplayName = "Client 11 15.x compatible",
+                Description = "10/11-compatible export for the extended client 11 executable; caps Market names at 29 characters.",
+                DatLayout = LegacyDatLayout.Tibia1098,
+                DatSignature = 0x00004A10,
+                SprSignature = 0x59E48E02,
+                Transparency = false,
+                SpriteIdsU32 = true,
+                IncludeEnhancedAnimations = true,
+                IncludeFrameGroups = true,
+                IncludeModernFlags = true,
+                LegacyOutfitAnimationFrames = 0,
+                MaxMarketNameLength = 29,
+            },
         ];
 
         public static IReadOnlyList<LegacyAssetExportProfile> All => Profiles;
@@ -97,6 +114,12 @@ namespace Assets_Editor
             if (string.Equals(id, "1098", StringComparison.OrdinalIgnoreCase))
             {
                 return Get("legacy1098");
+            }
+
+            if (string.Equals(id, "client11", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(id, "client-11", StringComparison.OrdinalIgnoreCase))
+            {
+                return Get("client11-15x");
             }
 
             throw new ArgumentException($"Unknown export profile '{id}'. Use --list-profiles to see valid profiles.");

--- a/Assets Editor/LegacyAssetExporter.cs
+++ b/Assets Editor/LegacyAssetExporter.cs
@@ -41,7 +41,7 @@ namespace Assets_Editor
             var backups = PrepareOutputFiles(options, datPath, sprPath);
 
             log?.Report($"Loading modern assets from '{options.InputPath}'");
-            var assets = ModernAssetSet.Load(options.InputPath);
+            using var assets = ModernAssetSet.Load(options.InputPath);
             var spriteStorage = new SpriteStorage();
             var spriteOffsets = new ConcurrentDictionary<string, uint>();
 
@@ -53,6 +53,7 @@ namespace Assets_Editor
 
             log?.Report($"Writing {options.Profile.DisplayName} dat");
             LegacyAppearance.WriteLegacyDat(datPath, options.Profile, legacyAppearances);
+            LegacyDatValidator.ValidateExport(datPath, options.Profile, (uint)Math.Max(0, spriteStorage.SprLists.Count - 1));
 
             log?.Report($"Writing {options.Profile.DisplayName} spr");
             await Sprite.CompileSpritesAsync(sprPath, spriteStorage, options.Profile.Transparency, options.Profile.SprSignature, sprCompileProgress);
@@ -139,10 +140,10 @@ namespace Assets_Editor
 
         private static void BuildLegacyAppearances(ModernAssetSet assets, Appearances appearances, ConcurrentDictionary<string, uint> spriteOffsets, LegacyAssetExportProfile profile, IProgress<string> log)
         {
-            var objectCount = appearances.Object.Count > 0 ? appearances.Object[^1].Id : 99;
-            var outfitCount = appearances.Outfit.Count > 0 ? appearances.Outfit[^1].Id : 0;
-            var effectCount = appearances.Effect.Count > 0 ? appearances.Effect[^1].Id : 0;
-            var missileCount = appearances.Missile.Count > 0 ? appearances.Missile[^1].Id : 0;
+            var objectCount = appearances.Object.Count > 0 ? appearances.Object.Max(item => item.Id) : 99;
+            var outfitCount = appearances.Outfit.Count > 0 ? appearances.Outfit.Max(item => item.Id) : 0;
+            var effectCount = appearances.Effect.Count > 0 ? appearances.Effect.Max(item => item.Id) : 0;
+            var missileCount = appearances.Missile.Count > 0 ? appearances.Missile.Max(item => item.Id) : 0;
 
             for (uint id = 100; id <= objectCount; id++)
             {
@@ -370,29 +371,22 @@ namespace Assets_Editor
             foreach (var spriteId in spriteInfo.SpriteId)
             {
                 var spriteName = spriteId.ToString();
-                try
+                switch (sliceType)
                 {
-                    if (sliceType == 0)
-                    {
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
-                    }
-                    else if (sliceType == 1 || sliceType == 2)
-                    {
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_1"]);
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
-                    }
-                    else if (sliceType == 3)
-                    {
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_3"]);
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_2"]);
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_1"]);
-                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
-                    }
-                }
-                catch (KeyNotFoundException)
-                {
-                    log?.Report($"Missing sliced sprite offset for appearance {appearanceId}, sprite {spriteId}; using blank sprite.");
-                    remappedSprites.Add(0);
+                    case 1:
+                    case 2:
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_1", appearanceId, spriteId, log);
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_0", appearanceId, spriteId, log);
+                        break;
+                    case 3:
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_3", appearanceId, spriteId, log);
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_2", appearanceId, spriteId, log);
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_1", appearanceId, spriteId, log);
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_0", appearanceId, spriteId, log);
+                        break;
+                    default:
+                        AddSpriteOffset(remappedSprites, spriteOffsets, $"{spriteName}_0", appearanceId, spriteId, log);
+                        break;
                 }
             }
 
@@ -401,6 +395,18 @@ namespace Assets_Editor
             {
                 spriteInfo.SpriteId.Add(spriteId);
             }
+        }
+
+        private static void AddSpriteOffset(List<uint> remappedSprites, ConcurrentDictionary<string, uint> spriteOffsets, string spriteKey, uint appearanceId, uint sourceSpriteId, IProgress<string> log)
+        {
+            if (spriteOffsets.TryGetValue(spriteKey, out var remappedSpriteId))
+            {
+                remappedSprites.Add(remappedSpriteId);
+                return;
+            }
+
+            log?.Report($"Missing sliced sprite offset for appearance {appearanceId}, sprite {sourceSpriteId}, slice {spriteKey}; using blank sprite.");
+            remappedSprites.Add(0);
         }
     }
 }

--- a/Assets Editor/LegacyAssetExporter.cs
+++ b/Assets Editor/LegacyAssetExporter.cs
@@ -1,0 +1,406 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Tibia.Protobuf.Appearances;
+
+namespace Assets_Editor
+{
+    public sealed class LegacyAssetExportOptions
+    {
+        public required string InputPath { get; init; }
+        public required string OutputPath { get; init; }
+        public required LegacyAssetExportProfile Profile { get; init; }
+        public bool Overwrite { get; init; }
+        public bool Backup { get; init; } = true;
+    }
+
+    public sealed class LegacyAssetExportResult
+    {
+        public required string DatPath { get; init; }
+        public required string SprPath { get; init; }
+        public required LegacyAssetExportProfile Profile { get; init; }
+        public IReadOnlyList<string> Backups { get; init; } = [];
+    }
+
+    public sealed class LegacyAssetExporter
+    {
+        public async Task<LegacyAssetExportResult> ExportAsync(LegacyAssetExportOptions options, IProgress<string> log = null, IProgress<int> spriteProgress = null, IProgress<int> sprCompileProgress = null)
+        {
+            ArgumentNullException.ThrowIfNull(options);
+            var outputPath = Path.GetFullPath(options.OutputPath);
+            Directory.CreateDirectory(outputPath);
+
+            var datPath = Path.Combine(outputPath, "Tibia.dat");
+            var sprPath = Path.Combine(outputPath, "Tibia.spr");
+            var backups = PrepareOutputFiles(options, datPath, sprPath);
+
+            log?.Report($"Loading modern assets from '{options.InputPath}'");
+            var assets = ModernAssetSet.Load(options.InputPath);
+            var spriteStorage = new SpriteStorage();
+            var spriteOffsets = new ConcurrentDictionary<string, uint>();
+
+            await Task.Run(() => BuildSpriteStorage(assets, spriteStorage, spriteOffsets, spriteProgress, log));
+
+            log?.Report("Building legacy appearance table");
+            var legacyAppearances = assets.Appearances.Clone();
+            BuildLegacyAppearances(assets, legacyAppearances, spriteOffsets, options.Profile, log);
+
+            log?.Report($"Writing {options.Profile.DisplayName} dat");
+            LegacyAppearance.WriteLegacyDat(datPath, options.Profile, legacyAppearances);
+
+            log?.Report($"Writing {options.Profile.DisplayName} spr");
+            await Sprite.CompileSpritesAsync(sprPath, spriteStorage, options.Profile.Transparency, options.Profile.SprSignature, sprCompileProgress);
+
+            return new LegacyAssetExportResult
+            {
+                DatPath = datPath,
+                SprPath = sprPath,
+                Profile = options.Profile,
+                Backups = backups,
+            };
+        }
+
+        private static List<string> PrepareOutputFiles(LegacyAssetExportOptions options, params string[] paths)
+        {
+            var backups = new List<string>();
+            foreach (var path in paths)
+            {
+                if (!File.Exists(path))
+                {
+                    continue;
+                }
+
+                if (!options.Overwrite)
+                {
+                    throw new IOException($"Output file already exists: '{path}'. Pass --overwrite to replace it.");
+                }
+
+                if (options.Backup)
+                {
+                    var backupPath = $"{path}.{DateTime.Now:yyyyMMddHHmmss}.bak";
+                    File.Copy(path, backupPath, overwrite: false);
+                    backups.Add(backupPath);
+                }
+            }
+
+            return backups;
+        }
+
+        private static void BuildSpriteStorage(ModernAssetSet assets, SpriteStorage spriteStorage, ConcurrentDictionary<string, uint> spriteOffsets, IProgress<int> progress, IProgress<string> log)
+        {
+            var sheets = assets.GetSpriteSheets().ToList();
+            var totalSprites = sheets.Sum(sheet => Math.Max(0, sheet.LastSpriteid - sheet.FirstSpriteid + 1));
+            var processedSprites = 0;
+            var lastProgress = -1;
+            uint nextSpriteId = 1;
+
+            foreach (var sheet in sheets)
+            {
+                for (var spriteId = sheet.FirstSpriteid; spriteId <= sheet.LastSpriteid; spriteId++)
+                {
+                    using var sourceStream = assets.GetSpriteStream(spriteId);
+                    using var bitmap = new Bitmap(sourceStream);
+                    var slices = SplitImage(bitmap);
+
+                    for (var sliceIndex = 0; sliceIndex < slices.Count; sliceIndex++)
+                    {
+                        using var slice = slices[sliceIndex];
+                        var spriteKey = $"{spriteId}_{sliceIndex}";
+                        if (IsImageFullyTransparent(slice))
+                        {
+                            spriteOffsets[spriteKey] = 0;
+                            continue;
+                        }
+
+                        var memoryStream = new MemoryStream();
+                        slice.Save(memoryStream, ImageFormat.Png);
+                        memoryStream.Position = 0;
+                        spriteStorage.SprLists[(int)nextSpriteId] = memoryStream;
+                        spriteOffsets[spriteKey] = nextSpriteId;
+                        nextSpriteId++;
+                    }
+
+                    processedSprites++;
+                    var currentProgress = totalSprites == 0 ? 100 : processedSprites * 100 / totalSprites;
+                    if (currentProgress != lastProgress)
+                    {
+                        progress?.Report(currentProgress);
+                        lastProgress = currentProgress;
+                    }
+                }
+            }
+        }
+
+        private static void BuildLegacyAppearances(ModernAssetSet assets, Appearances appearances, ConcurrentDictionary<string, uint> spriteOffsets, LegacyAssetExportProfile profile, IProgress<string> log)
+        {
+            var objectCount = appearances.Object.Count > 0 ? appearances.Object[^1].Id : 99;
+            var outfitCount = appearances.Outfit.Count > 0 ? appearances.Outfit[^1].Id : 0;
+            var effectCount = appearances.Effect.Count > 0 ? appearances.Effect[^1].Id : 0;
+            var missileCount = appearances.Missile.Count > 0 ? appearances.Missile[^1].Id : 0;
+
+            for (uint id = 100; id <= objectCount; id++)
+            {
+                var appearance = appearances.Object.FirstOrDefault(item => item.Id == id);
+                if (appearance == null)
+                {
+                    appearances.Object.Add(CreateBlankObject(id, APPEARANCE_TYPE.AppearanceObject));
+                    continue;
+                }
+
+                appearance.AppearanceType = APPEARANCE_TYPE.AppearanceObject;
+                NormalizeHookFlags(appearance);
+                UpdateAppearanceObject(assets, appearance, spriteOffsets, profile, log);
+            }
+
+            for (uint id = 1; id <= outfitCount; id++)
+            {
+                var appearance = appearances.Outfit.FirstOrDefault(item => item.Id == id);
+                if (appearance == null)
+                {
+                    appearances.Outfit.Add(CreateBlankObject(id, APPEARANCE_TYPE.AppearanceOutfit));
+                    continue;
+                }
+
+                appearance.AppearanceType = APPEARANCE_TYPE.AppearanceOutfit;
+                UpdateAppearanceObject(assets, appearance, spriteOffsets, profile, log);
+            }
+
+            for (uint id = 1; id <= effectCount; id++)
+            {
+                var appearance = appearances.Effect.FirstOrDefault(item => item.Id == id);
+                if (appearance == null)
+                {
+                    appearances.Effect.Add(CreateBlankObject(id, APPEARANCE_TYPE.AppearanceEffect));
+                    continue;
+                }
+
+                appearance.AppearanceType = APPEARANCE_TYPE.AppearanceEffect;
+                UpdateAppearanceObject(assets, appearance, spriteOffsets, profile, log);
+            }
+
+            for (uint id = 1; id <= missileCount; id++)
+            {
+                var appearance = appearances.Missile.FirstOrDefault(item => item.Id == id);
+                if (appearance == null)
+                {
+                    appearances.Missile.Add(CreateBlankObject(id, APPEARANCE_TYPE.AppearanceMissile));
+                    continue;
+                }
+
+                appearance.AppearanceType = APPEARANCE_TYPE.AppearanceMissile;
+                UpdateAppearanceObject(assets, appearance, spriteOffsets, profile, log);
+            }
+        }
+
+        private static List<Bitmap> SplitImage(Bitmap originalImage)
+        {
+            var splitImages = new List<Bitmap>();
+            var rows = originalImage.Height / Sprite.DefaultSize;
+            var columns = originalImage.Width / Sprite.DefaultSize;
+
+            for (var row = 0; row < rows; row++)
+            {
+                for (var column = 0; column < columns; column++)
+                {
+                    var cloneRect = new Rectangle(column * Sprite.DefaultSize, row * Sprite.DefaultSize, Sprite.DefaultSize, Sprite.DefaultSize);
+                    splitImages.Add(originalImage.Clone(cloneRect, originalImage.PixelFormat));
+                }
+            }
+
+            return splitImages;
+        }
+
+        private static bool IsImageFullyTransparent(Bitmap image)
+        {
+            if (Image.GetPixelFormatSize(image.PixelFormat) < 32)
+            {
+                return false;
+            }
+
+            var rect = new Rectangle(0, 0, image.Width, image.Height);
+            var bitmapData = image.LockBits(rect, ImageLockMode.ReadOnly, image.PixelFormat);
+            try
+            {
+                var bytes = Math.Abs(bitmapData.Stride) * image.Height;
+                var values = new byte[bytes];
+                Marshal.Copy(bitmapData.Scan0, values, 0, bytes);
+
+                for (var index = 0; index < values.Length; index += 4)
+                {
+                    if (values[index + 3] != 0)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            finally
+            {
+                image.UnlockBits(bitmapData);
+            }
+        }
+
+        private static Appearance CreateBlankObject(uint id, APPEARANCE_TYPE type)
+        {
+            var appearance = new Appearance
+            {
+                AppearanceType = type,
+                Id = id,
+                Flags = new AppearanceFlags(),
+            };
+
+            var frameGroup = new FrameGroup
+            {
+                FixedFrameGroup = FIXED_FRAME_GROUP.OutfitIdle,
+                SpriteInfo = new SpriteInfo
+                {
+                    PatternWidth = 1,
+                    PatternHeight = 1,
+                    PatternSize = Sprite.DefaultSize,
+                    PatternLayers = 1,
+                    PatternX = 1,
+                    PatternY = 1,
+                    PatternZ = 1,
+                    PatternFrames = 1,
+                }
+            };
+            frameGroup.SpriteInfo.SpriteId.Add(0);
+            appearance.FrameGroup.Add(frameGroup);
+            return appearance;
+        }
+
+        private static void NormalizeHookFlags(Appearance appearance)
+        {
+            if (appearance.Flags?.Hook == null)
+            {
+                return;
+            }
+
+            if (appearance.Flags.Hook.Direction == HOOK_TYPE.South)
+            {
+                appearance.Flags.HookSouth = true;
+            }
+
+            if (appearance.Flags.Hook.Direction == HOOK_TYPE.East)
+            {
+                appearance.Flags.HookEast = true;
+            }
+        }
+
+        private static void UpdateAppearanceObject(ModernAssetSet assets, Appearance appearance, ConcurrentDictionary<string, uint> spriteOffsets, LegacyAssetExportProfile profile, IProgress<string> log)
+        {
+            if (appearance.FrameGroup.Count == 0)
+            {
+                appearance.FrameGroup.Add(CreateBlankObject(appearance.Id, appearance.AppearanceType).FrameGroup[0]);
+            }
+
+            for (var frameIndex = 0; frameIndex < appearance.FrameGroup.Count; frameIndex++)
+            {
+                var frameGroup = appearance.FrameGroup[frameIndex];
+                var spriteInfo = frameGroup.SpriteInfo;
+                if (spriteInfo == null || spriteInfo.SpriteId.Count == 0)
+                {
+                    frameGroup.SpriteInfo = CreateBlankObject(appearance.Id, appearance.AppearanceType).FrameGroup[0].SpriteInfo;
+                    continue;
+                }
+
+                uint width = 1;
+                uint height = 1;
+                uint exactSize = Sprite.DefaultSize;
+                var sliceType = assets.GetSheetType(spriteInfo.SpriteId[0]);
+                if (sliceType == 1)
+                {
+                    height = 2;
+                }
+                else if (sliceType == 2)
+                {
+                    width = 2;
+                }
+                else if (sliceType == 3)
+                {
+                    width = 2;
+                    height = 2;
+                }
+
+                if (width > 1 || height > 1)
+                {
+                    if (spriteInfo.BoundingBoxPerDirection.Count > 0)
+                    {
+                        exactSize = Math.Max(spriteInfo.BoundingBoxPerDirection[0].Width, spriteInfo.BoundingBoxPerDirection[0].Height);
+                    }
+                    else
+                    {
+                        log?.Report($"Missing bounding box for appearance {appearance.Id}; using 32px exact size.");
+                    }
+                }
+
+                var sourcePatternWidth = spriteInfo.PatternWidth == 0 ? 1 : spriteInfo.PatternWidth;
+                var sourcePatternHeight = spriteInfo.PatternHeight == 0 ? 1 : spriteInfo.PatternHeight;
+
+                spriteInfo.PatternX = sourcePatternWidth;
+                spriteInfo.PatternY = sourcePatternHeight;
+                spriteInfo.PatternWidth = width;
+                spriteInfo.PatternHeight = height;
+                spriteInfo.PatternSize = exactSize;
+                spriteInfo.PatternLayers = spriteInfo.Layers == 0 ? Math.Max(spriteInfo.PatternLayers, 1) : spriteInfo.Layers;
+                spriteInfo.PatternZ = spriteInfo.PatternDepth == 0 ? Math.Max(spriteInfo.PatternZ, 1) : spriteInfo.PatternDepth;
+                spriteInfo.PatternFrames = spriteInfo.Animation?.SpritePhase.Count > 0
+                    ? (uint)spriteInfo.Animation.SpritePhase.Count
+                    : Math.Max(spriteInfo.PatternFrames, 1);
+
+                RemapSprites(spriteInfo, spriteOffsets, sliceType, appearance.Id, log);
+
+                if (!profile.IncludeEnhancedAnimations)
+                {
+                    spriteInfo.Animation = null;
+                }
+            }
+        }
+
+        private static void RemapSprites(SpriteInfo spriteInfo, ConcurrentDictionary<string, uint> spriteOffsets, int sliceType, uint appearanceId, IProgress<string> log)
+        {
+            var remappedSprites = new List<uint>();
+            foreach (var spriteId in spriteInfo.SpriteId)
+            {
+                var spriteName = spriteId.ToString();
+                try
+                {
+                    if (sliceType == 0)
+                    {
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
+                    }
+                    else if (sliceType == 1 || sliceType == 2)
+                    {
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_1"]);
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
+                    }
+                    else if (sliceType == 3)
+                    {
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_3"]);
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_2"]);
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_1"]);
+                        remappedSprites.Add(spriteOffsets[$"{spriteName}_0"]);
+                    }
+                }
+                catch (KeyNotFoundException)
+                {
+                    log?.Report($"Missing sliced sprite offset for appearance {appearanceId}, sprite {spriteId}; using blank sprite.");
+                    remappedSprites.Add(0);
+                }
+            }
+
+            spriteInfo.SpriteId.Clear();
+            foreach (var spriteId in remappedSprites)
+            {
+                spriteInfo.SpriteId.Add(spriteId);
+            }
+        }
+    }
+}

--- a/Assets Editor/LegacyAssetExporter.cs
+++ b/Assets Editor/LegacyAssetExporter.cs
@@ -18,6 +18,7 @@ namespace Assets_Editor
         public required LegacyAssetExportProfile Profile { get; init; }
         public bool Overwrite { get; init; }
         public bool Backup { get; init; } = true;
+        public bool ExportItemFlagOtml { get; init; } = true;
     }
 
     public sealed class LegacyAssetExportResult
@@ -25,6 +26,8 @@ namespace Assets_Editor
         public required string DatPath { get; init; }
         public required string SprPath { get; init; }
         public required LegacyAssetExportProfile Profile { get; init; }
+        public string ItemFlagOtmlPath { get; init; }
+        public int ItemFlagOtmlItems { get; init; }
         public IReadOnlyList<string> Backups { get; init; } = [];
     }
 
@@ -38,7 +41,14 @@ namespace Assets_Editor
 
             var datPath = Path.Combine(outputPath, "Tibia.dat");
             var sprPath = Path.Combine(outputPath, "Tibia.spr");
-            var backups = PrepareOutputFiles(options, datPath, sprPath);
+            var itemFlagOtmlPath = Path.Combine(outputPath, LegacyItemFlagOtmlExporter.FileName);
+            var outputFiles = new List<string> { datPath, sprPath };
+            if (options.ExportItemFlagOtml)
+            {
+                outputFiles.Add(itemFlagOtmlPath);
+            }
+
+            var backups = PrepareOutputFiles(options, outputFiles.ToArray());
 
             log?.Report($"Loading modern assets from '{options.InputPath}'");
             using var assets = ModernAssetSet.Load(options.InputPath);
@@ -58,11 +68,20 @@ namespace Assets_Editor
             log?.Report($"Writing {options.Profile.DisplayName} spr");
             await Sprite.CompileSpritesAsync(sprPath, spriteStorage, options.Profile.Transparency, options.Profile.SprSignature, sprCompileProgress);
 
+            var itemFlagOtmlItems = 0;
+            if (options.ExportItemFlagOtml)
+            {
+                log?.Report($"Writing item flag sidecar '{itemFlagOtmlPath}'");
+                itemFlagOtmlItems = LegacyItemFlagOtmlExporter.Write(itemFlagOtmlPath, assets.Appearances, options.Profile);
+            }
+
             return new LegacyAssetExportResult
             {
                 DatPath = datPath,
                 SprPath = sprPath,
                 Profile = options.Profile,
+                ItemFlagOtmlPath = options.ExportItemFlagOtml ? itemFlagOtmlPath : null,
+                ItemFlagOtmlItems = itemFlagOtmlItems,
                 Backups = backups,
             };
         }

--- a/Assets Editor/LegacyDatValidator.cs
+++ b/Assets Editor/LegacyDatValidator.cs
@@ -1,0 +1,345 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Tibia.Protobuf.Appearances;
+
+namespace Assets_Editor
+{
+    public static class LegacyDatValidator
+    {
+        public static void ValidateFiles(string datPath, string sprPath, LegacyAssetExportProfile profile)
+        {
+            ValidateExport(datPath, profile, ReadSprSpriteCount(sprPath, profile));
+        }
+
+        public static void ValidateExport(string datPath, LegacyAssetExportProfile profile, uint maxSpriteId)
+        {
+            using var stream = File.OpenRead(datPath);
+            using var reader = new BinaryReader(stream);
+
+            var signature = reader.ReadUInt32();
+            if (signature != profile.DatSignature)
+            {
+                throw new InvalidDataException($"Invalid dat signature 0x{signature:X8}; expected 0x{profile.DatSignature:X8} for profile '{profile.Id}'.");
+            }
+
+            var objectCount = reader.ReadUInt16();
+            var outfitCount = reader.ReadUInt16();
+            var effectCount = reader.ReadUInt16();
+            var missileCount = reader.ReadUInt16();
+
+            ReadRange(reader, profile, APPEARANCE_TYPE.AppearanceObject, 100, objectCount, maxSpriteId);
+            ReadRange(reader, profile, APPEARANCE_TYPE.AppearanceOutfit, 1, outfitCount, maxSpriteId);
+            ReadRange(reader, profile, APPEARANCE_TYPE.AppearanceEffect, 1, effectCount, maxSpriteId);
+            ReadRange(reader, profile, APPEARANCE_TYPE.AppearanceMissile, 1, missileCount, maxSpriteId);
+
+            if (stream.Position != stream.Length)
+            {
+                throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': parser stopped at {stream.Position}, file length is {stream.Length}.");
+            }
+        }
+
+        public static uint ReadSprSpriteCount(string sprPath, LegacyAssetExportProfile profile)
+        {
+            using var stream = File.OpenRead(sprPath);
+            using var reader = new BinaryReader(stream);
+
+            var signature = reader.ReadUInt32();
+            if (signature != profile.SprSignature)
+            {
+                throw new InvalidDataException($"Invalid spr signature 0x{signature:X8}; expected 0x{profile.SprSignature:X8} for profile '{profile.Id}'.");
+            }
+
+            return profile.SpriteIdsU32 ? reader.ReadUInt32() : reader.ReadUInt16();
+        }
+
+        private static void ReadRange(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint firstId, uint lastId, uint maxSpriteId)
+        {
+            if (lastId < firstId)
+            {
+                return;
+            }
+
+            for (var id = firstId; id <= lastId; id++)
+            {
+                ReadAppearance(reader, profile, type, id, maxSpriteId);
+            }
+        }
+
+        private static void ReadAppearance(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, uint maxSpriteId)
+        {
+            if (profile.DatLayout == LegacyDatLayout.Tibia860)
+            {
+                ReadAttributes860(reader, profile, type, id);
+                ReadSpriteInfo(reader, profile, type, id, maxSpriteId);
+                return;
+            }
+
+            ReadAttributes1098(reader, profile, type, id);
+
+            var frameGroupCount = 1;
+            if (type == APPEARANCE_TYPE.AppearanceOutfit && profile.IncludeFrameGroups)
+            {
+                frameGroupCount = ReadByte(reader, profile, type, id, "frame group count");
+                if (frameGroupCount == 0)
+                {
+                    throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} has zero frame groups.");
+                }
+            }
+
+            for (var group = 0; group < frameGroupCount; group++)
+            {
+                if (type == APPEARANCE_TYPE.AppearanceOutfit && profile.IncludeFrameGroups)
+                {
+                    ReadByte(reader, profile, type, id, "frame group type");
+                }
+
+                ReadSpriteInfo(reader, profile, type, id, maxSpriteId);
+            }
+        }
+
+        private static void ReadAttributes860(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id)
+        {
+            while (true)
+            {
+                var attr = ReadByte(reader, profile, type, id, "attribute");
+                if (attr == 0xFF)
+                {
+                    return;
+                }
+
+                if (attr == (byte)AppearanceFlag860.Clothes && !profile.IncludeModernFlags)
+                {
+                    throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} writes unsupported Clothes/attr 32.");
+                }
+
+                switch ((AppearanceFlag860)attr)
+                {
+                    case AppearanceFlag860.Ground:
+                    case AppearanceFlag860.Writeable:
+                    case AppearanceFlag860.WriteableOnce:
+                    case AppearanceFlag860.LightSource:
+                    case AppearanceFlag860.Displaced:
+                    case AppearanceFlag860.Elevated:
+                    case AppearanceFlag860.MinimapColor:
+                    case AppearanceFlag860.HelpInfo:
+                    case AppearanceFlag860.Clothes:
+                        SkipPayload860(reader, (AppearanceFlag860)attr);
+                        break;
+                    case AppearanceFlag860.Clip:
+                    case AppearanceFlag860.Bottom:
+                    case AppearanceFlag860.Top:
+                    case AppearanceFlag860.Container:
+                    case AppearanceFlag860.Stackable:
+                    case AppearanceFlag860.ForceUse:
+                    case AppearanceFlag860.Multiuse:
+                    case AppearanceFlag860.LiquidContainer:
+                    case AppearanceFlag860.LiquidPool:
+                    case AppearanceFlag860.Impassable:
+                    case AppearanceFlag860.Unmovable:
+                    case AppearanceFlag860.BlocksSight:
+                    case AppearanceFlag860.BlocksPathfinding:
+                    case AppearanceFlag860.Pickupable:
+                    case AppearanceFlag860.Hangable:
+                    case AppearanceFlag860.HooksSouth:
+                    case AppearanceFlag860.HooksEast:
+                    case AppearanceFlag860.Rotateable:
+                    case AppearanceFlag860.AlwaysSeen:
+                    case AppearanceFlag860.Translucent:
+                    case AppearanceFlag860.LyingObject:
+                    case AppearanceFlag860.AlwaysAnimated:
+                    case AppearanceFlag860.FullTile:
+                    case AppearanceFlag860.Lookthrough:
+                        break;
+                    default:
+                        throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} has unsupported 8.60 attr {attr}.");
+                }
+            }
+        }
+
+        private static void ReadAttributes1098(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id)
+        {
+            while (true)
+            {
+                var attr = ReadByte(reader, profile, type, id, "attribute");
+                if (attr == 0xFF)
+                {
+                    return;
+                }
+
+                switch ((AppearanceFlag1098)attr)
+                {
+                    case AppearanceFlag1098.Ground:
+                    case AppearanceFlag1098.Writeable:
+                    case AppearanceFlag1098.WriteableOnce:
+                    case AppearanceFlag1098.LightSource:
+                    case AppearanceFlag1098.Displaced:
+                    case AppearanceFlag1098.Elevated:
+                    case AppearanceFlag1098.MinimapColor:
+                    case AppearanceFlag1098.HelpInfo:
+                    case AppearanceFlag1098.Clothes:
+                    case AppearanceFlag1098.DefaultAction:
+                        SkipPayload1098(reader, (AppearanceFlag1098)attr);
+                        break;
+                    case AppearanceFlag1098.Market:
+                        ReadMarket(reader, profile, type, id);
+                        break;
+                    case AppearanceFlag1098.Clip:
+                    case AppearanceFlag1098.Bottom:
+                    case AppearanceFlag1098.Top:
+                    case AppearanceFlag1098.Container:
+                    case AppearanceFlag1098.Stackable:
+                    case AppearanceFlag1098.ForceUse:
+                    case AppearanceFlag1098.Usable:
+                    case AppearanceFlag1098.Multiuse:
+                    case AppearanceFlag1098.LiquidContainer:
+                    case AppearanceFlag1098.LiquidPool:
+                    case AppearanceFlag1098.Impassable:
+                    case AppearanceFlag1098.Unmovable:
+                    case AppearanceFlag1098.BlocksSight:
+                    case AppearanceFlag1098.BlocksPathfinding:
+                    case AppearanceFlag1098.NoMovementAnimation:
+                    case AppearanceFlag1098.Pickupable:
+                    case AppearanceFlag1098.Hangable:
+                    case AppearanceFlag1098.HooksSouth:
+                    case AppearanceFlag1098.HooksEast:
+                    case AppearanceFlag1098.Rotateable:
+                    case AppearanceFlag1098.AlwaysSeen:
+                    case AppearanceFlag1098.Translucent:
+                    case AppearanceFlag1098.LyingObject:
+                    case AppearanceFlag1098.AlwaysAnimated:
+                    case AppearanceFlag1098.FullTile:
+                    case AppearanceFlag1098.Lookthrough:
+                    case AppearanceFlag1098.Wrappable:
+                    case AppearanceFlag1098.UnWrappable:
+                    case AppearanceFlag1098.TopEffect:
+                        break;
+                    default:
+                        throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} has unsupported 10/11 attr {attr}.");
+                }
+            }
+        }
+
+        private static void ReadMarket(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id)
+        {
+            ReadUInt16(reader, profile, type, id, "market category");
+            ReadUInt16(reader, profile, type, id, "market trade as");
+            ReadUInt16(reader, profile, type, id, "market show as");
+            var nameLength = ReadUInt16(reader, profile, type, id, "market name length");
+            if (profile.MaxMarketNameLength > 0 && nameLength > profile.MaxMarketNameLength)
+            {
+                throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} market name length is {nameLength}, max is {profile.MaxMarketNameLength}.");
+            }
+
+            Skip(reader, nameLength, profile, type, id, "market name");
+            ReadUInt16(reader, profile, type, id, "market vocation");
+            ReadUInt16(reader, profile, type, id, "market level");
+        }
+
+        private static void ReadSpriteInfo(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, uint maxSpriteId)
+        {
+            var width = ReadByte(reader, profile, type, id, "sprite width");
+            var height = ReadByte(reader, profile, type, id, "sprite height");
+            if (width == 0 || height == 0)
+            {
+                throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} has zero sprite dimensions.");
+            }
+
+            if (width > 1 || height > 1)
+            {
+                ReadByte(reader, profile, type, id, "sprite exact size");
+            }
+
+            var layers = ReadByte(reader, profile, type, id, "sprite layers");
+            var patternX = ReadByte(reader, profile, type, id, "sprite pattern x");
+            var patternY = ReadByte(reader, profile, type, id, "sprite pattern y");
+            var patternZ = ReadByte(reader, profile, type, id, "sprite pattern z");
+            var frames = ReadByte(reader, profile, type, id, "sprite frames");
+
+            if (layers == 0 || patternX == 0 || patternY == 0 || patternZ == 0 || frames == 0)
+            {
+                throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} has zero sprite pattern data.");
+            }
+
+            if (profile.IncludeEnhancedAnimations && frames > 1)
+            {
+                ReadByte(reader, profile, type, id, "animation mode");
+                ReadUInt32(reader, profile, type, id, "animation loop count");
+                ReadByte(reader, profile, type, id, "animation default phase");
+                for (var phase = 0; phase < frames; phase++)
+                {
+                    ReadUInt32(reader, profile, type, id, "animation min duration");
+                    ReadUInt32(reader, profile, type, id, "animation max duration");
+                }
+            }
+
+            var spriteCount = (uint)width * height * layers * patternX * patternY * patternZ * frames;
+            for (var sprite = 0; sprite < spriteCount; sprite++)
+            {
+                var spriteId = profile.SpriteIdsU32
+                    ? ReadUInt32(reader, profile, type, id, "sprite id")
+                    : ReadUInt16(reader, profile, type, id, "sprite id");
+
+                if (spriteId > maxSpriteId)
+                {
+                    throw new InvalidDataException($"Dat validation failed for profile '{profile.Id}': {type} {id} references sprite {spriteId}, but spr has only {maxSpriteId} sprites.");
+                }
+            }
+        }
+
+        private static void SkipPayload860(BinaryReader reader, AppearanceFlag860 attr)
+        {
+            var bytes = attr switch
+            {
+                AppearanceFlag860.LightSource or AppearanceFlag860.Displaced => 4,
+                _ => 2,
+            };
+            Skip(reader, bytes, null, default, 0, attr.ToString());
+        }
+
+        private static void SkipPayload1098(BinaryReader reader, AppearanceFlag1098 attr)
+        {
+            var bytes = attr switch
+            {
+                AppearanceFlag1098.LightSource or AppearanceFlag1098.Displaced => 4,
+                _ => 2,
+            };
+            Skip(reader, bytes, null, default, 0, attr.ToString());
+        }
+
+        private static byte ReadByte(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, string field)
+        {
+            EnsureAvailable(reader, 1, profile, type, id, field);
+            return reader.ReadByte();
+        }
+
+        private static ushort ReadUInt16(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, string field)
+        {
+            EnsureAvailable(reader, 2, profile, type, id, field);
+            return reader.ReadUInt16();
+        }
+
+        private static uint ReadUInt32(BinaryReader reader, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, string field)
+        {
+            EnsureAvailable(reader, 4, profile, type, id, field);
+            return reader.ReadUInt32();
+        }
+
+        private static void Skip(BinaryReader reader, int bytes, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, string field)
+        {
+            EnsureAvailable(reader, bytes, profile, type, id, field);
+            reader.BaseStream.Seek(bytes, SeekOrigin.Current);
+        }
+
+        private static void EnsureAvailable(BinaryReader reader, int bytes, LegacyAssetExportProfile profile, APPEARANCE_TYPE type, uint id, string field)
+        {
+            if (reader.BaseStream.Position + bytes <= reader.BaseStream.Length)
+            {
+                return;
+            }
+
+            var profileId = profile?.Id ?? "unknown";
+            throw new InvalidDataException($"Dat validation failed for profile '{profileId}': EOF while reading {field} for {type} {id} at offset {reader.BaseStream.Position}.");
+        }
+    }
+}

--- a/Assets Editor/LegacyItemFlagOtmlExporter.cs
+++ b/Assets Editor/LegacyItemFlagOtmlExporter.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using Tibia.Protobuf.Appearances;
+
+namespace Assets_Editor
+{
+    public static class LegacyItemFlagOtmlExporter
+    {
+        public const string FileName = "itemFlag.otml";
+
+        public static int Write(string outputPath, Appearances appearances, LegacyAssetExportProfile profile)
+        {
+            ArgumentNullException.ThrowIfNull(appearances);
+            ArgumentNullException.ThrowIfNull(profile);
+
+            var root = OTMLNode.Create("items");
+            var itemCount = 0;
+
+            foreach (var item in appearances.Object.OrderBy(item => item.Id))
+            {
+                if (item.Flags == null)
+                {
+                    continue;
+                }
+
+                var itemNode = OTMLNode.Create(ToString(item.Id));
+                AddItemFlags(itemNode, item.Flags, profile);
+                if (itemNode.Children.Count == 0)
+                {
+                    continue;
+                }
+
+                root.AddChild(itemNode);
+                itemCount++;
+            }
+
+            File.WriteAllText(outputPath, root.Emit() + "\n");
+            return itemCount;
+        }
+
+        private static void AddItemFlags(OTMLNode itemNode, AppearanceFlags flags, LegacyAssetExportProfile profile)
+        {
+            if (!profile.IncludeModernFlags)
+            {
+                if (flags.NoMovementAnimation)
+                    AddBool(itemNode, "noMovementAnimation");
+
+                if (flags.Clothes != null)
+                    AddValue(itemNode, "cloth", ToClothSlotName(flags.Clothes.Slot));
+
+                if (flags.DefaultAction != null)
+                    AddValue(itemNode, "defaultAction", ToDefaultActionName(flags.DefaultAction.Action));
+
+                if (flags.Wrap)
+                    AddBool(itemNode, "wrap");
+
+                if (flags.Unwrap)
+                    AddBool(itemNode, "unwrap");
+
+                if (flags.Topeffect)
+                    AddBool(itemNode, "topEffect");
+            }
+
+            if (flags.Changedtoexpire != null)
+                AddValue(itemNode, "changedToExpire", flags.Changedtoexpire.HasFormerObjectTypeid ? flags.Changedtoexpire.FormerObjectTypeid : 0);
+
+            if (flags.Corpse)
+                AddBool(itemNode, "corpse");
+
+            if (flags.PlayerCorpse)
+                AddBool(itemNode, "playerCorpse");
+
+            if (flags.Cyclopediaitem != null)
+                AddValue(itemNode, "cyclopediaType", flags.Cyclopediaitem.HasCyclopediaType ? flags.Cyclopediaitem.CyclopediaType : 0);
+
+            if (flags.Ammo)
+                AddBool(itemNode, "ammo");
+
+            if (flags.ShowOffSocket)
+                AddBool(itemNode, "showOffSocket");
+
+            if (flags.Reportable)
+                AddBool(itemNode, "reportable");
+
+            if (flags.Upgradeclassification != null)
+                AddValue(itemNode, "classification", flags.Upgradeclassification.HasUpgradeClassification ? flags.Upgradeclassification.UpgradeClassification : 0);
+
+            if (flags.ReverseAddonsEast)
+                AddBool(itemNode, "reverseAddonsEast");
+
+            if (flags.ReverseAddonsWest)
+                AddBool(itemNode, "reverseAddonsWest");
+
+            if (flags.ReverseAddonsSouth)
+                AddBool(itemNode, "reverseAddonsSouth");
+
+            if (flags.ReverseAddonsNorth)
+                AddBool(itemNode, "reverseAddonsNorth");
+
+            if (flags.Wearout)
+                AddBool(itemNode, "charges");
+
+            if (flags.Clockexpire)
+                AddBool(itemNode, "duration");
+
+            if (flags.Expire)
+                AddBool(itemNode, "expire");
+
+            if (flags.Expirestop)
+                AddBool(itemNode, "expireStop");
+
+            if (flags.DecoItemKit)
+                AddBool(itemNode, "decoKit");
+
+            if (flags.SkillwheelGem != null)
+                AddSkillWheelGem(itemNode, flags.SkillwheelGem);
+
+            if (flags.DualWielding)
+                AddBool(itemNode, "dualWielding");
+
+            if (flags.Imbueable != null)
+                AddValue(itemNode, "imbueSlots", flags.Imbueable.HasSlotCount ? flags.Imbueable.SlotCount : 0);
+
+            if (flags.Proficiency != null)
+                AddValue(itemNode, "proficiency", flags.Proficiency.HasProficiencyId ? flags.Proficiency.ProficiencyId : 0);
+
+            if (flags.RestrictToVocation.Count > 0)
+                AddVocationList(itemNode, "restrictVocation", flags.RestrictToVocation);
+
+            if (flags.HasMinimumLevel)
+                AddValue(itemNode, "minimumLevel", flags.MinimumLevel);
+
+            if (flags.HasWeaponType)
+                AddValue(itemNode, "weaponType", ToWeaponTypeName(flags.WeaponType));
+
+            if (flags.Transparencylevel != null)
+                AddValue(itemNode, "transparencyLevel", flags.Transparencylevel.HasLevel ? flags.Transparencylevel.Level : 0);
+        }
+
+        private static void AddSkillWheelGem(OTMLNode itemNode, AppearanceFlagSkillWheelGem flag)
+        {
+            var node = OTMLNode.Create("skillWheelGem");
+            if (flag.HasGemQualityId)
+                AddValue(node, "gemQualityId", flag.GemQualityId);
+
+            if (flag.HasVocationId)
+                AddValue(node, "vocationId", flag.VocationId);
+
+            if (node.Children.Count > 0)
+                itemNode.AddChild(node);
+            else
+                AddBool(itemNode, "skillWheelGem");
+        }
+
+        private static void AddVocationList(OTMLNode itemNode, string tag, Google.Protobuf.Collections.RepeatedField<VOCATION> values)
+        {
+            var node = OTMLNode.Create(tag);
+            foreach (var value in values)
+            {
+                node.AddChild(OTMLNode.Create(string.Empty, ToVocationName(value)));
+            }
+
+            itemNode.AddChild(node);
+        }
+
+        private static void AddBool(OTMLNode node, string tag)
+        {
+            AddValue(node, tag, "true");
+        }
+
+        private static void AddValue(OTMLNode node, string tag, uint value)
+        {
+            AddValue(node, tag, ToString(value));
+        }
+
+        private static void AddValue(OTMLNode node, string tag, string value)
+        {
+            node.AddChild(OTMLNode.Create(tag, value));
+        }
+
+        private static string ToString(uint value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string ToString(int value)
+        {
+            return value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static string ToClothSlotName(uint slot)
+        {
+            return slot switch
+            {
+                1 => "helmet",
+                2 => "amulet",
+                3 => "backpack",
+                4 => "armor",
+                5 => "shield",
+                6 => "weapon",
+                7 => "legs",
+                8 => "boots",
+                9 => "ring",
+                10 => "arrow",
+                _ => "none",
+            };
+        }
+
+        private static string ToDefaultActionName(PLAYER_ACTION action)
+        {
+            return (int)action switch
+            {
+                1 => "look",
+                2 => "use",
+                3 => "open",
+                4 => "autowalkHighlight",
+                _ => "none",
+            };
+        }
+
+        private static string ToVocationName(VOCATION vocation)
+        {
+            return (int)vocation switch
+            {
+                -1 => "any",
+                0 => "none",
+                1 => "knight",
+                2 => "paladin",
+                3 => "sorcerer",
+                4 => "druid",
+                5 => "monk",
+                10 => "promoted",
+                _ => ToString((int)vocation),
+            };
+        }
+
+        private static string ToWeaponTypeName(WEAPON_TYPE weaponType)
+        {
+            return (int)weaponType switch
+            {
+                1 => "sword",
+                2 => "axe",
+                3 => "club",
+                4 => "fist",
+                5 => "bow",
+                6 => "crossbow",
+                7 => "wandRod",
+                8 => "throw",
+                _ => "none",
+            };
+        }
+    }
+}

--- a/Assets Editor/ModernAssetSet.cs
+++ b/Assets Editor/ModernAssetSet.cs
@@ -11,7 +11,7 @@ using Tibia.Protobuf.Appearances;
 
 namespace Assets_Editor
 {
-    public sealed class ModernAssetSet
+    public sealed class ModernAssetSet : IDisposable
     {
         private readonly object loadLock = new();
         private readonly ConcurrentDictionary<int, MemoryStream> spriteStreams = new();
@@ -110,6 +110,16 @@ namespace Assets_Editor
         public IEnumerable<MainWindow.Catalog> GetSpriteSheets()
         {
             return Catalog.Where(entry => entry.Type == "sprite" && entry.SpriteType >= 0);
+        }
+
+        public void Dispose()
+        {
+            foreach (var stream in spriteStreams.Values)
+            {
+                stream?.Dispose();
+            }
+
+            spriteStreams.Clear();
         }
 
         private void GenerateTileSetImageList(Bitmap bitmap, MainWindow.Catalog sheet)

--- a/Assets Editor/ModernAssetSet.cs
+++ b/Assets Editor/ModernAssetSet.cs
@@ -1,0 +1,191 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using Tibia.Protobuf.Appearances;
+
+namespace Assets_Editor
+{
+    public sealed class ModernAssetSet
+    {
+        private readonly object loadLock = new();
+        private readonly ConcurrentDictionary<int, MemoryStream> spriteStreams = new();
+
+        private ModernAssetSet(string assetsPath, List<MainWindow.Catalog> catalog, Appearances appearances)
+        {
+            AssetsPath = assetsPath;
+            Catalog = catalog;
+            Appearances = appearances;
+            spriteStreams[0] = CreateBlankSpriteStream();
+        }
+
+        public string AssetsPath { get; }
+        public List<MainWindow.Catalog> Catalog { get; }
+        public Appearances Appearances { get; }
+
+        public static ModernAssetSet Load(string inputPath)
+        {
+            var assetsPath = ResolveAssetsPath(inputPath);
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                DefaultValueHandling = DefaultValueHandling.Ignore,
+                MissingMemberHandling = MissingMemberHandling.Ignore
+            };
+
+            var catalogPath = Path.Combine(assetsPath, "catalog-content.json");
+            var catalog = JsonConvert.DeserializeObject<List<MainWindow.Catalog>>(File.ReadAllText(catalogPath), settings);
+            if (catalog == null || catalog.Count == 0)
+            {
+                throw new InvalidOperationException($"No catalog entries found in '{catalogPath}'.");
+            }
+
+            var appearanceEntry = catalog.FirstOrDefault(entry => entry.Type == "appearances") ?? catalog[0];
+            var appearancePath = Path.Combine(assetsPath, appearanceEntry.File);
+            if (!File.Exists(appearancePath))
+            {
+                throw new FileNotFoundException("Appearance protobuf was not found.", appearancePath);
+            }
+
+            using var appearanceStream = File.OpenRead(appearancePath);
+            var appearances = Appearances.Parser.ParseFrom(appearanceStream);
+            return new ModernAssetSet(assetsPath, catalog, appearances);
+        }
+
+        public MemoryStream GetSpriteStream(int spriteId)
+        {
+            if (spriteStreams.TryGetValue(spriteId, out var cached) && cached != null)
+            {
+                return CloneStream(cached);
+            }
+
+            var sheet = Catalog.FirstOrDefault(entry =>
+                entry.Type == "sprite" &&
+                spriteId >= entry.FirstSpriteid &&
+                spriteId <= entry.LastSpriteid);
+
+            if (sheet == null)
+            {
+                return CloneStream(spriteStreams[0]);
+            }
+
+            lock (loadLock)
+            {
+                if (!spriteStreams.TryGetValue(spriteId, out cached) || cached == null)
+                {
+                    var spritePath = Path.Combine(AssetsPath, sheet.File);
+                    if (!File.Exists(spritePath))
+                    {
+                        throw new FileNotFoundException("Sprite sheet was not found.", spritePath);
+                    }
+
+                    using var bitmap = LZMA.DecompressFileLZMA(spritePath);
+                    GenerateTileSetImageList(bitmap, sheet);
+                }
+            }
+
+            if (!spriteStreams.TryGetValue(spriteId, out cached) || cached == null)
+            {
+                return CloneStream(spriteStreams[0]);
+            }
+
+            return CloneStream(cached);
+        }
+
+        public int GetSheetType(uint spriteId)
+        {
+            var sheet = Catalog.FirstOrDefault(entry =>
+                entry.Type == "sprite" &&
+                entry.FirstSpriteid <= spriteId &&
+                entry.LastSpriteid >= spriteId);
+
+            return sheet?.SpriteType ?? 0;
+        }
+
+        public IEnumerable<MainWindow.Catalog> GetSpriteSheets()
+        {
+            return Catalog.Where(entry => entry.Type == "sprite" && entry.SpriteType >= 0);
+        }
+
+        private void GenerateTileSetImageList(Bitmap bitmap, MainWindow.Catalog sheet)
+        {
+            var tileCount = sheet.LastSpriteid - sheet.FirstSpriteid;
+            var spriteCount = 0;
+
+            var xCols = sheet.SpriteType is 0 or 1 ? 12 : 6;
+            var yCols = sheet.SpriteType is 0 or 2 ? 12 : 6;
+            var tileWidth = sheet.SpriteType is 0 or 1 ? 32 : 64;
+            var tileHeight = sheet.SpriteType is 0 or 2 ? 32 : 64;
+
+            for (var row = 0; row < yCols; row++)
+            {
+                for (var column = 0; column < xCols; column++)
+                {
+                    if (spriteCount > tileCount)
+                    {
+                        break;
+                    }
+
+                    using var tile = new Bitmap(tileWidth, tileHeight, bitmap.PixelFormat);
+                    using var graphics = Graphics.FromImage(tile);
+                    var sourceRect = new Rectangle(column * tileWidth, row * tileHeight, tileWidth, tileHeight);
+                    graphics.DrawImage(bitmap, new Rectangle(0, 0, tileWidth, tileHeight), sourceRect, GraphicsUnit.Pixel);
+
+                    var stream = new MemoryStream();
+                    tile.Save(stream, ImageFormat.Png);
+                    stream.Position = 0;
+                    spriteStreams[sheet.FirstSpriteid + spriteCount] = stream;
+                    spriteCount++;
+                }
+            }
+        }
+
+        private static string ResolveAssetsPath(string inputPath)
+        {
+            if (string.IsNullOrWhiteSpace(inputPath))
+            {
+                throw new ArgumentException("Input path is required.", nameof(inputPath));
+            }
+
+            var fullPath = Path.GetFullPath(inputPath);
+            var candidates = new[]
+            {
+                fullPath,
+                Path.Combine(fullPath, "assets"),
+                Path.GetFullPath(Path.Combine(fullPath, "..", "assets")),
+            };
+
+            foreach (var candidate in candidates.Distinct(StringComparer.OrdinalIgnoreCase))
+            {
+                if (Directory.Exists(candidate) && File.Exists(Path.Combine(candidate, "catalog-content.json")))
+                {
+                    return candidate;
+                }
+            }
+
+            throw new DirectoryNotFoundException($"Could not find catalog-content.json from input path '{inputPath}'.");
+        }
+
+        private static MemoryStream CloneStream(MemoryStream source)
+        {
+            lock (source)
+            {
+                return new MemoryStream(source.ToArray());
+            }
+        }
+
+        private static MemoryStream CreateBlankSpriteStream()
+        {
+            using var bitmap = new Bitmap(32, 32, PixelFormat.Format32bppArgb);
+            var stream = new MemoryStream();
+            bitmap.Save(stream, ImageFormat.Png);
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ Assets Editor is an open-source tool designed for modifying and managing client 
 #### Usage
 - Download the latest release from the [Releases](https://github.com/Arch-Mina/Assets-Editor/releases) page.
 
-### Legacy export profiles
+#### Legacy export profiles
 
 The command line exporter can generate legacy `.dat/.spr` pairs:
 
 ```powershell
 & ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
+& ".\Assets Editor.exe" validate-legacy --profile client11-15x --dat <client-path>\Tibia.dat [--spr <client-path>\Tibia.spr]
 ```
 
 `cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
@@ -59,6 +60,8 @@ This matters because the CipSoft 8.60 parser aborts on unknown modern dat attrib
 - Uses signature `0x00004A10` for `.dat` and `0x59E48E02` for `.spr`.
 - Writes extended `uint32` sprite ids.
 - Caps Market names at 29 characters. This client fails to open `Tibia.dat` when a Market name is 30 characters or longer, so the exporter truncates the name before serialization.
+
+The exporter validates the generated `.dat` before writing the `.spr`. The validator checks the selected profile contract, parser alignment, Market name limits, frame group data, animation phase data, and sprite id references. Use `validate-legacy` on shared files before opening them in the CipSoft client; a validator error is safer than a client access violation on startup.
 
 :sparkles: **Supporting the Project**
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ The command line exporter can generate legacy `.dat/.spr` pairs:
 
 ```powershell
 & ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
+& ".\Assets Editor.exe" export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
 & ".\Assets Editor.exe" validate-legacy --profile client11-15x --dat <client-path>\Tibia.dat [--spr <client-path>\Tibia.spr]
 ```
+
+The UI legacy exporter uses the same profiles. By default it writes to `legacy-exports\<profile>` under the application folder, and the dialog also has a custom output option when you want to export directly to another directory.
 
 `cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
 

--- a/README.md
+++ b/README.md
@@ -36,63 +36,9 @@ Assets Editor is an open-source tool designed for modifying and managing client 
 #### Usage
 - Download the latest release from the [Releases](https://github.com/Arch-Mina/Assets-Editor/releases) page.
 
-#### Legacy export profiles
+#### Legacy export
 
-The command line exporter can generate legacy `.dat/.spr` pairs:
-
-```powershell
-& ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
-& ".\Assets Editor.exe" export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
-& ".\Assets Editor.exe" validate-legacy --profile client11-15x --dat <client-path>\Tibia.dat [--spr <client-path>\Tibia.spr]
-```
-
-The UI legacy exporter uses the same profiles. By default it writes to `legacy-exports\<profile>` under the application folder, and the dialog also has a custom output option when you want to export directly to another directory.
-
-Legacy export also writes an `itemFlag.otml` sidecar next to `Tibia.dat` and `Tibia.spr` by default. This file preserves protobuf item flags that are not represented by the selected legacy `.dat` contract. Pass `--no-item-flag-otml` to skip it. Existing `itemFlag.otml` files follow the same `--overwrite` and `--no-backup` behavior as the generated `.dat/.spr` files.
-
-`itemFlag.otml` is an overlay for compatible OTClient forks. It does not affect clients unless they explicitly load it after the legacy things files, for example with `g_things.loadOtml("things/{version}/itemFlag.otml")`, and extend `ThingType::unserializeOtml()` to apply the supported tags.
-
-Example sidecar:
-
-```otml
-items
-  3046
-    duration: true
-
-  3047
-    classification: 1
-
-  3051
-    duration: true
-    cloth: ring
-    decoKit: true
-
-  2222
-    proficiency: 2
-    restrictVocation
-      - knight
-      - paladin
-```
-
-The sidecar may include tags such as `charges`, `duration`, `classification`, `decoKit`, `proficiency`, `skillWheelGem`, `imbueSlots`, `dualWielding`, `minimumLevel`, `weaponType`, and `restrictVocation`. For `cip860-extended`, it may also carry modern tags intentionally omitted from the 8.60 `.dat`, such as `cloth`, `defaultAction`, `wrap`, `unwrap`, and `topEffect`.
-
-`cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
-
-- Writes classic 8.60 dat attributes only.
-- Does not write modern dat flags such as `Clothes`/attr 32, `Market`, `DefaultAction`, `Wrap`, or `TopEffect`.
-- Writes extended `uint32` sprite ids for clients patched to read the extended `.spr`.
-- Keeps the classic outfit layout. Outfit colors come from the game protocol fields `lookHead`, `lookBody`, `lookLegs`, `lookFeet`, and `lookAddons`, not from the modern `Clothes` dat flag.
-
-This matters because the CipSoft 8.60 parser aborts on unknown modern dat attributes. A file that includes `Clothes`/attr 32 is not a valid `cip860-extended` export unless the client binary is separately patched to understand that flag.
-
-`client11-15x` targets the extended client 11 executable used with 15.x assets:
-
-- Writes the 10/11 dat layout with modern legacy flags enabled.
-- Uses signature `0x00004A10` for `.dat` and `0x59E48E02` for `.spr`.
-- Writes extended `uint32` sprite ids.
-- Caps Market names at 29 characters. This client fails to open `Tibia.dat` when a Market name is 30 characters or longer, so the exporter truncates the name before serialization.
-
-The exporter validates the generated `.dat` before writing the `.spr`. The validator checks the selected profile contract, parser alignment, Market name limits, frame group data, animation phase data, and sprite id references. Use `validate-legacy` on shared files before opening them in the CipSoft client; a validator error is safer than a client access violation on startup.
+Assets Editor can export modern assets to legacy `.dat/.spr` profiles for 8.60 and 11/15.x clients. See the [legacy export guide](docs/legacy-export.md) for CLI commands, UI output behavior, profile contracts, validation, and `itemFlag.otml` sidecar details.
 
 :sparkles: **Supporting the Project**
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,23 @@ Assets Editor is an open-source tool designed for modifying and managing client 
 #### Usage
 - Download the latest release from the [Releases](https://github.com/Arch-Mina/Assets-Editor/releases) page.
 
+### Legacy export profiles
+
+The command line exporter can generate legacy `.dat/.spr` pairs:
+
+```powershell
+& ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
+```
+
+`cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
+
+- Writes classic 8.60 dat attributes only.
+- Does not write modern dat flags such as `Clothes`/attr 32, `Market`, `DefaultAction`, `Wrap`, or `TopEffect`.
+- Writes extended `uint32` sprite ids for clients patched to read the extended `.spr`.
+- Keeps the classic outfit layout. Outfit colors come from the game protocol fields `lookHead`, `lookBody`, `lookLegs`, `lookFeet`, and `lookAddons`, not from the modern `Clothes` dat flag.
+
+This matters because the CipSoft 8.60 parser aborts on unknown modern dat attributes. A file that includes `Clothes`/attr 32 is not a valid `cip860-extended` export unless the client binary is separately patched to understand that flag.
+
 :sparkles: **Supporting the Project**
 
 If you find this project useful and want to show your appreciation or support, you're welcome to do so through [PayPal](https://paypal.me/SpiderOT?country.x=EG&locale.x=en_US). Your support is entirely optional but greatly appreciated :heart:.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ The command line exporter can generate legacy `.dat/.spr` pairs:
 
 This matters because the CipSoft 8.60 parser aborts on unknown modern dat attributes. A file that includes `Clothes`/attr 32 is not a valid `cip860-extended` export unless the client binary is separately patched to understand that flag.
 
+`client11-15x` targets the extended client 11 executable used with 15.x assets:
+
+- Writes the 10/11 dat layout with modern legacy flags enabled.
+- Uses signature `0x00004A10` for `.dat` and `0x59E48E02` for `.spr`.
+- Writes extended `uint32` sprite ids.
+- Caps Market names at 29 characters. This client fails to open `Tibia.dat` when a Market name is 30 characters or longer, so the exporter truncates the name before serialization.
+
 :sparkles: **Supporting the Project**
 
 If you find this project useful and want to show your appreciation or support, you're welcome to do so through [PayPal](https://paypal.me/SpiderOT?country.x=EG&locale.x=en_US). Your support is entirely optional but greatly appreciated :heart:.

--- a/README.md
+++ b/README.md
@@ -41,12 +41,40 @@ Assets Editor is an open-source tool designed for modifying and managing client 
 The command line exporter can generate legacy `.dat/.spr` pairs:
 
 ```powershell
-& ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
-& ".\Assets Editor.exe" export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup]
+& ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
+& ".\Assets Editor.exe" export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
 & ".\Assets Editor.exe" validate-legacy --profile client11-15x --dat <client-path>\Tibia.dat [--spr <client-path>\Tibia.spr]
 ```
 
 The UI legacy exporter uses the same profiles. By default it writes to `legacy-exports\<profile>` under the application folder, and the dialog also has a custom output option when you want to export directly to another directory.
+
+Legacy export also writes an `itemFlag.otml` sidecar next to `Tibia.dat` and `Tibia.spr` by default. This file preserves protobuf item flags that are not represented by the selected legacy `.dat` contract. Pass `--no-item-flag-otml` to skip it. Existing `itemFlag.otml` files follow the same `--overwrite` and `--no-backup` behavior as the generated `.dat/.spr` files.
+
+`itemFlag.otml` is an overlay for compatible OTClient forks. It does not affect clients unless they explicitly load it after the legacy things files, for example with `g_things.loadOtml("things/{version}/itemFlag.otml")`, and extend `ThingType::unserializeOtml()` to apply the supported tags.
+
+Example sidecar:
+
+```otml
+items
+  3046
+    duration: true
+
+  3047
+    classification: 1
+
+  3051
+    duration: true
+    cloth: ring
+    decoKit: true
+
+  2222
+    proficiency: 2
+    restrictVocation
+      - knight
+      - paladin
+```
+
+The sidecar may include tags such as `charges`, `duration`, `classification`, `decoKit`, `proficiency`, `skillWheelGem`, `imbueSlots`, `dualWielding`, `minimumLevel`, `weaponType`, and `restrictVocation`. For `cip860-extended`, it may also carry modern tags intentionally omitted from the 8.60 `.dat`, such as `cloth`, `defaultAction`, `wrap`, `unwrap`, and `topEffect`.
 
 `cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,13 @@
 image: Visual Studio 2022
 
+install:
+  - ps: |
+      $ErrorActionPreference = "Stop"
+      $dotnetInstall = Join-Path $env:TEMP "dotnet-install.ps1"
+      Invoke-WebRequest "https://dot.net/v1/dotnet-install.ps1" -OutFile $dotnetInstall
+      & $dotnetInstall -Channel 10.0 -Quality ga -InstallDir "$env:ProgramFiles\dotnet"
+      dotnet --list-sdks
+
 before_build:
   - dotnet restore "Assets Editor/Assets Editor.sln"
 

--- a/docs/legacy-export.md
+++ b/docs/legacy-export.md
@@ -1,0 +1,71 @@
+# Legacy Export
+
+Assets Editor can generate legacy `.dat/.spr` pairs from modern assets through either the command line or the UI legacy exporter.
+
+## Command Line
+
+Run these commands from the directory that contains `Assets Editor.exe`:
+
+```powershell
+& ".\Assets Editor.exe" export-legacy --profile cip860-extended --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
+& ".\Assets Editor.exe" export-legacy --profile client11-15x --input <assets-or-bin-path> --output <client-path> [--overwrite] [--no-backup] [--no-item-flag-otml]
+& ".\Assets Editor.exe" validate-legacy --profile client11-15x --dat <client-path>\Tibia.dat [--spr <client-path>\Tibia.spr]
+```
+
+The exporter writes `Tibia.dat`, `Tibia.spr`, and, unless disabled, `itemFlag.otml` to the selected output directory. Existing output files require `--overwrite`; backups are created by default unless `--no-backup` is passed.
+
+## UI Export
+
+The UI legacy exporter uses the same profiles as the CLI. By default it writes to `legacy-exports\<profile>` under the application folder, and the dialog also has a custom output option when you want to export directly to another directory.
+
+## Profiles
+
+`cip860-extended` is intentionally a CipSoft 8.60 object layout with selected extensions, not a modern OTClient dat layout:
+
+- Writes classic 8.60 dat attributes only.
+- Does not write modern dat flags such as `Clothes`/attr 32, `Market`, `DefaultAction`, `Wrap`, or `TopEffect`.
+- Writes extended `uint32` sprite ids for clients patched to read the extended `.spr`.
+- Keeps the classic outfit layout. Outfit colors come from the game protocol fields `lookHead`, `lookBody`, `lookLegs`, `lookFeet`, and `lookAddons`, not from the modern `Clothes` dat flag.
+
+This matters because the CipSoft 8.60 parser aborts on unknown modern dat attributes. A file that includes `Clothes`/attr 32 is not a valid `cip860-extended` export unless the client binary is separately patched to understand that flag.
+
+`client11-15x` targets the extended client 11 executable used with 15.x assets:
+
+- Writes the 10/11 dat layout with modern legacy flags enabled.
+- Uses signature `0x00004A10` for `.dat` and `0x59E48E02` for `.spr`.
+- Writes extended `uint32` sprite ids.
+- Caps Market names at 29 characters. This client fails to open `Tibia.dat` when a Market name is 30 characters or longer, so the exporter truncates the name before serialization.
+
+## Item Flag Sidecar
+
+Legacy export writes an `itemFlag.otml` sidecar next to `Tibia.dat` and `Tibia.spr` by default. This file preserves protobuf item flags that are not represented by the selected legacy `.dat` contract. Pass `--no-item-flag-otml` to skip it.
+
+`itemFlag.otml` is an overlay for compatible OTClient forks. It does not affect clients unless they explicitly load it after the legacy things files, for example with `g_things.loadOtml("things/{version}/itemFlag.otml")`, and extend `ThingType::unserializeOtml()` to apply the supported tags.
+
+Example sidecar:
+
+```otml
+items
+  3046
+    duration: true
+
+  3047
+    classification: 1
+
+  3051
+    duration: true
+    cloth: ring
+    decoKit: true
+
+  2222
+    proficiency: 2
+    restrictVocation
+      - knight
+      - paladin
+```
+
+The sidecar may include tags such as `charges`, `duration`, `classification`, `decoKit`, `proficiency`, `skillWheelGem`, `imbueSlots`, `dualWielding`, `minimumLevel`, `weaponType`, and `restrictVocation`. For `cip860-extended`, it may also carry modern tags intentionally omitted from the 8.60 `.dat`, such as `cloth`, `defaultAction`, `wrap`, `unwrap`, and `topEffect`.
+
+## Validation
+
+The exporter validates the generated `.dat` before writing the `.spr`. The validator checks the selected profile contract, parser alignment, Market name limits, frame group data, animation phase data, and sprite id references. Use `validate-legacy` on shared files before opening them in the CipSoft client; a validator error is safer than a client access violation on startup.


### PR DESCRIPTION
## Summary
- Adds a CLI `export-legacy` command and `--list-profiles` entry point for generating legacy `.dat/.spr` pairs from modern assets.
- Adds legacy export profiles for `cip860-extended` and `client11-15x`, including DAT layout/signature settings, extended sprite IDs, outfit frame handling, and Market name limits.
- Adds modern asset loading, sprite slicing/remapping, backup/overwrite handling, and README documentation for the supported profiles and compatibility notes.

## Validation
- Not run (not requested).